### PR TITLE
Fix: Rename namespace after move to @ergebnis

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
 use Ergebnis\PhpCsFixer\Config;
@@ -19,7 +19,7 @@ Copyright (c) 2018 Andreas Möller
 For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 
-@see https://github.com/localheinz/phpstan-rules
+@see https://github.com/ergebnis/phpstan-rules
 EOF;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($header));

--- a/.php_cs.fixture
+++ b/.php_cs.fixture
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
 use Ergebnis\PhpCsFixer\Config;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,37 @@ For a full diff see [`0.13.0...master`][0.13.0...master].
 ### Changed
 
 * Allowed installation of `phpstan/phpstan:~0.12.0`  ([#147], by [@localheinz]
+* Renamed vendor namespace `Localheinz` to `Ergebnis` after move to [@ergebnis] ([#157]), by [@localheinz]
+
+  Run
+
+  ```
+  $ composer remove localheinz/phpstan-rules
+  ```
+
+  and
+
+  ```
+  $ composer require ergebnis/phpstan-rules
+  ```
+
+  to update.
+
+  Run
+
+  ```
+  $ find . -type f -exec sed -i '.bak' 's/Localheinz\\PHPStan/Ergebnis\\PHPStan/g' {} \;
+  ```
+
+  to replace occurrences of `Localheinz\PHPStan` with `Ergebnis\PHPStan`.
+
+  Run
+
+  ```
+  $ find -type f -name '*.bak' -delete
+  ```
+
+  to delete backup files created in the previous step.
 
 ### Fixed
 
@@ -194,85 +225,87 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 
 * Added `Classes\AbstractOrFinalRule`, which reports an error when a non-anonymous class is neither `abstract` nor `final`, ([#1]), by [@localheinz]
 
-[0.1.0]: https://github.com/localheinz/phpstan-rules/releases/tag/0.1.0
-[0.2.0]: https://github.com/localheinz/phpstan-rules/releases/tag/0.2.0
-[0.3.0]: https://github.com/localheinz/phpstan-rules/releases/tag/0.3.0
-[0.4.0]: https://github.com/localheinz/phpstan-rules/releases/tag/0.4.0
-[0.5.0]: https://github.com/localheinz/phpstan-rules/releases/tag/0.5.0
-[0.6.0]: https://github.com/localheinz/phpstan-rules/releases/tag/0.6.0
-[0.7.0]: https://github.com/localheinz/phpstan-rules/releases/tag/0.7.0
-[0.7.1]: https://github.com/localheinz/phpstan-rules/releases/tag/0.7.1
-[0.8.0]: https://github.com/localheinz/phpstan-rules/releases/tag/0.8.0
-[0.8.1]: https://github.com/localheinz/phpstan-rules/releases/tag/0.8.1
-[0.9.0]: https://github.com/localheinz/phpstan-rules/releases/tag/0.9.0
-[0.9.1]: https://github.com/localheinz/phpstan-rules/releases/tag/0.9.1
-[0.10.0]: https://github.com/localheinz/phpstan-rules/releases/tag/0.10.0
-[0.11.0]: https://github.com/localheinz/phpstan-rules/releases/tag/0.11.0
-[0.12.0]: https://github.com/localheinz/phpstan-rules/releases/tag/0.12.0
-[0.12.1]: https://github.com/localheinz/phpstan-rules/releases/tag/0.12.1
-[0.12.2]: https://github.com/localheinz/phpstan-rules/releases/tag/0.12.2
-[0.13.0]: https://github.com/localheinz/phpstan-rules/releases/tag/0.13.0
+[0.1.0]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.1.0
+[0.2.0]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.2.0
+[0.3.0]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.3.0
+[0.4.0]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.4.0
+[0.5.0]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.5.0
+[0.6.0]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.6.0
+[0.7.0]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.7.0
+[0.7.1]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.7.1
+[0.8.0]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.8.0
+[0.8.1]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.8.1
+[0.9.0]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.9.0
+[0.9.1]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.9.1
+[0.10.0]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.10.0
+[0.11.0]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.11.0
+[0.12.0]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.12.0
+[0.12.1]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.12.1
+[0.12.2]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.12.2
+[0.13.0]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.13.0
 
-[362c7ea...0.1.0]: https://github.com/localheinz/phpstan-rules/compare/362c7ea...0.1.0
-[0.1.0...0.2.0]: https://github.com/localheinz/phpstan-rules/compare/0.1.0...0.2.0
-[0.2.0...0.3.0]: https://github.com/localheinz/phpstan-rules/compare/0.2.0...0.3.0
-[0.3.0...0.4.0]: https://github.com/localheinz/phpstan-rules/compare/0.3.0...0.4.0
-[0.4.0...0.5.0]: https://github.com/localheinz/phpstan-rules/compare/0.4.0...0.5.0
-[0.5.0...0.6.0]: https://github.com/localheinz/phpstan-rules/compare/0.5.0...0.6.0
-[0.6.0...0.7.0]: https://github.com/localheinz/phpstan-rules/compare/0.6.0...0.7.0
-[0.7.0...0.7.1]: https://github.com/localheinz/phpstan-rules/compare/0.7.0...0.7.1
-[0.7.1...0.8.0]: https://github.com/localheinz/phpstan-rules/compare/0.7.1...0.8.0
-[0.8.0...0.8.1]: https://github.com/localheinz/phpstan-rules/compare/0.8.0...0.8.1
-[0.8.1...0.9.0]: https://github.com/localheinz/phpstan-rules/compare/0.8.1...0.9.0
-[0.9.0...0.9.1]: https://github.com/localheinz/phpstan-rules/compare/0.9.0...0.9.1
-[0.9.1...0.10.0]: https://github.com/localheinz/phpstan-rules/compare/0.9.1...0.10.0
-[0.10.0...0.11.0]: https://github.com/localheinz/phpstan-rules/compare/0.10.0...0.11.0
-[0.11.0...0.12.0]: https://github.com/localheinz/phpstan-rules/compare/0.11.0...0.12.0
-[0.12.0...0.12.1]: https://github.com/localheinz/phpstan-rules/compare/0.12.0...0.12.1
-[0.12.1...0.12.2]: https://github.com/localheinz/phpstan-rules/compare/0.12.1...0.12.2
-[0.12.2...0.13.0]: https://github.com/localheinz/phpstan-rules/compare/0.12.2...0.13.0
-[0.13.0...master]: https://github.com/localheinz/phpstan-rules/compare/0.13.0...master
+[362c7ea...0.1.0]: https://github.com/ergebnis/phpstan-rules/compare/362c7ea...0.1.0
+[0.1.0...0.2.0]: https://github.com/ergebnis/phpstan-rules/compare/0.1.0...0.2.0
+[0.2.0...0.3.0]: https://github.com/ergebnis/phpstan-rules/compare/0.2.0...0.3.0
+[0.3.0...0.4.0]: https://github.com/ergebnis/phpstan-rules/compare/0.3.0...0.4.0
+[0.4.0...0.5.0]: https://github.com/ergebnis/phpstan-rules/compare/0.4.0...0.5.0
+[0.5.0...0.6.0]: https://github.com/ergebnis/phpstan-rules/compare/0.5.0...0.6.0
+[0.6.0...0.7.0]: https://github.com/ergebnis/phpstan-rules/compare/0.6.0...0.7.0
+[0.7.0...0.7.1]: https://github.com/ergebnis/phpstan-rules/compare/0.7.0...0.7.1
+[0.7.1...0.8.0]: https://github.com/ergebnis/phpstan-rules/compare/0.7.1...0.8.0
+[0.8.0...0.8.1]: https://github.com/ergebnis/phpstan-rules/compare/0.8.0...0.8.1
+[0.8.1...0.9.0]: https://github.com/ergebnis/phpstan-rules/compare/0.8.1...0.9.0
+[0.9.0...0.9.1]: https://github.com/ergebnis/phpstan-rules/compare/0.9.0...0.9.1
+[0.9.1...0.10.0]: https://github.com/ergebnis/phpstan-rules/compare/0.9.1...0.10.0
+[0.10.0...0.11.0]: https://github.com/ergebnis/phpstan-rules/compare/0.10.0...0.11.0
+[0.11.0...0.12.0]: https://github.com/ergebnis/phpstan-rules/compare/0.11.0...0.12.0
+[0.12.0...0.12.1]: https://github.com/ergebnis/phpstan-rules/compare/0.12.0...0.12.1
+[0.12.1...0.12.2]: https://github.com/ergebnis/phpstan-rules/compare/0.12.1...0.12.2
+[0.12.2...0.13.0]: https://github.com/ergebnis/phpstan-rules/compare/0.12.2...0.13.0
+[0.13.0...master]: https://github.com/ergebnis/phpstan-rules/compare/0.13.0...master
 
-[#1]: https://github.com/localheinz/phpstan-rules/pull/1
-[#4]: https://github.com/localheinz/phpstan-rules/pull/4
-[#11]: https://github.com/localheinz/phpstan-rules/pull/11
-[#16]: https://github.com/localheinz/phpstan-rules/pull/16
-[#26]: https://github.com/localheinz/phpstan-rules/pull/26
-[#29]: https://github.com/localheinz/phpstan-rules/pull/29
-[#31]: https://github.com/localheinz/phpstan-rules/pull/31
-[#32]: https://github.com/localheinz/phpstan-rules/pull/32
-[#33]: https://github.com/localheinz/phpstan-rules/pull/33
-[#34]: https://github.com/localheinz/phpstan-rules/pull/34
-[#35]: https://github.com/localheinz/phpstan-rules/pull/35
-[#37]: https://github.com/localheinz/phpstan-rules/pull/37
-[#39]: https://github.com/localheinz/phpstan-rules/pull/39
-[#42]: https://github.com/localheinz/phpstan-rules/pull/42
-[#45]: https://github.com/localheinz/phpstan-rules/pull/45
-[#51]: https://github.com/localheinz/phpstan-rules/pull/51
-[#53]: https://github.com/localheinz/phpstan-rules/pull/53
-[#65]: https://github.com/localheinz/phpstan-rules/pull/65
-[#68]: https://github.com/localheinz/phpstan-rules/pull/68
-[#73]: https://github.com/localheinz/phpstan-rules/pull/73
-[#79]: https://github.com/localheinz/phpstan-rules/pull/79
-[#81]: https://github.com/localheinz/phpstan-rules/pull/81
-[#83]: https://github.com/localheinz/phpstan-rules/pull/83
-[#84]: https://github.com/localheinz/phpstan-rules/pull/84
-[#89]: https://github.com/localheinz/phpstan-rules/pull/89
-[#91]: https://github.com/localheinz/phpstan-rules/pull/91
-[#93]: https://github.com/localheinz/phpstan-rules/pull/93
-[#102]: https://github.com/localheinz/phpstan-rules/pull/102
-[#103]: https://github.com/localheinz/phpstan-rules/pull/103
-[#110]: https://github.com/localheinz/phpstan-rules/pull/110
-[#112]: https://github.com/localheinz/phpstan-rules/pull/112
-[#113]: https://github.com/localheinz/phpstan-rules/pull/113
-[#116]: https://github.com/localheinz/phpstan-rules/pull/116
-[#117]: https://github.com/localheinz/phpstan-rules/pull/117
-[#122]: https://github.com/localheinz/phpstan-rules/pull/122
-[#123]: https://github.com/localheinz/phpstan-rules/pull/123
-[#126]: https://github.com/localheinz/phpstan-rules/pull/126
-[#128]: https://github.com/localheinz/phpstan-rules/pull/128
-[#132]: https://github.com/localheinz/phpstan-rules/pull/132
-[#141]: https://github.com/localheinz/phpstan-rules/pull/141
-[#147]: https://github.com/localheinz/phpstan-rules/pull/147
+[#1]: https://github.com/ergebnis/phpstan-rules/pull/1
+[#4]: https://github.com/ergebnis/phpstan-rules/pull/4
+[#11]: https://github.com/ergebnis/phpstan-rules/pull/11
+[#16]: https://github.com/ergebnis/phpstan-rules/pull/16
+[#26]: https://github.com/ergebnis/phpstan-rules/pull/26
+[#29]: https://github.com/ergebnis/phpstan-rules/pull/29
+[#31]: https://github.com/ergebnis/phpstan-rules/pull/31
+[#32]: https://github.com/ergebnis/phpstan-rules/pull/32
+[#33]: https://github.com/ergebnis/phpstan-rules/pull/33
+[#34]: https://github.com/ergebnis/phpstan-rules/pull/34
+[#35]: https://github.com/ergebnis/phpstan-rules/pull/35
+[#37]: https://github.com/ergebnis/phpstan-rules/pull/37
+[#39]: https://github.com/ergebnis/phpstan-rules/pull/39
+[#42]: https://github.com/ergebnis/phpstan-rules/pull/42
+[#45]: https://github.com/ergebnis/phpstan-rules/pull/45
+[#51]: https://github.com/ergebnis/phpstan-rules/pull/51
+[#53]: https://github.com/ergebnis/phpstan-rules/pull/53
+[#65]: https://github.com/ergebnis/phpstan-rules/pull/65
+[#68]: https://github.com/ergebnis/phpstan-rules/pull/68
+[#73]: https://github.com/ergebnis/phpstan-rules/pull/73
+[#79]: https://github.com/ergebnis/phpstan-rules/pull/79
+[#81]: https://github.com/ergebnis/phpstan-rules/pull/81
+[#83]: https://github.com/ergebnis/phpstan-rules/pull/83
+[#84]: https://github.com/ergebnis/phpstan-rules/pull/84
+[#89]: https://github.com/ergebnis/phpstan-rules/pull/89
+[#91]: https://github.com/ergebnis/phpstan-rules/pull/91
+[#93]: https://github.com/ergebnis/phpstan-rules/pull/93
+[#102]: https://github.com/ergebnis/phpstan-rules/pull/102
+[#103]: https://github.com/ergebnis/phpstan-rules/pull/103
+[#110]: https://github.com/ergebnis/phpstan-rules/pull/110
+[#112]: https://github.com/ergebnis/phpstan-rules/pull/112
+[#113]: https://github.com/ergebnis/phpstan-rules/pull/113
+[#116]: https://github.com/ergebnis/phpstan-rules/pull/116
+[#117]: https://github.com/ergebnis/phpstan-rules/pull/117
+[#122]: https://github.com/ergebnis/phpstan-rules/pull/122
+[#123]: https://github.com/ergebnis/phpstan-rules/pull/123
+[#126]: https://github.com/ergebnis/phpstan-rules/pull/126
+[#128]: https://github.com/ergebnis/phpstan-rules/pull/128
+[#132]: https://github.com/ergebnis/phpstan-rules/pull/132
+[#141]: https://github.com/ergebnis/phpstan-rules/pull/141
+[#147]: https://github.com/ergebnis/phpstan-rules/pull/147
+[#157]: https://github.com/ergebnis/phpstan-rules/pull/157
 
+[@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # phpstan-rules
 
-[![Continuous Integration](https://github.com/localheinz/phpstan-rules/workflows/Continuous%20Integration/badge.svg)](https://github.com/localheinz/phpstan-rules/actions)
-[![Code Coverage](https://codecov.io/gh/localheinz/phpstan-rules/branch/master/graph/badge.svg)](https://codecov.io/gh/localheinz/phpstan-rules)
-[![Latest Stable Version](https://poser.pugx.org/localheinz/phpstan-rules/v/stable)](https://packagist.org/packages/localheinz/phpstan-rules)
-[![Total Downloads](https://poser.pugx.org/localheinz/phpstan-rules/downloads)](https://packagist.org/packages/localheinz/phpstan-rules)
+[![Continuous Integration](https://github.com/ergebnis/phpstan-rules/workflows/Continuous%20Integration/badge.svg)](https://github.com/ergebnis/phpstan-rules/actions)
+[![Code Coverage](https://codecov.io/gh/ergebnis/phpstan-rules/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/phpstan-rules)
+[![Latest Stable Version](https://poser.pugx.org/ergebnis/phpstan-rules/v/stable)](https://packagist.org/packages/ergebnis/phpstan-rules)
+[![Total Downloads](https://poser.pugx.org/ergebnis/phpstan-rules/downloads)](https://packagist.org/packages/ergebnis/phpstan-rules)
 
 Provides additional rules for [`phpstan/phpstan`](https://github.com/phpstan/phpstan).
 
@@ -12,12 +12,12 @@ Provides additional rules for [`phpstan/phpstan`](https://github.com/phpstan/php
 Run
 
 ```
-$ composer require --dev localheinz/phpstan-rules
+$ composer require --dev ergebnis/phpstan-rules
 ```
 
 ## Usage
 
-All of the [rules](https://github.com/localheinz/phpstan-rules#rules) provided (and used) by this library are included in [`rules.neon`](rules.neon).
+All of the [rules](https://github.com/ergebnis/phpstan-rules#rules) provided (and used) by this library are included in [`rules.neon`](rules.neon).
 
 When you are using [`phpstan/extension-installer`](https://github.com/phpstan/extension-installer), `rules.neon` will be automatically included.
 
@@ -25,7 +25,7 @@ Otherwise you need to include `rules.neon` in your `phpstan.neon`:
 
 ```neon
 includes:
-	- vendor/localheinz/phpstan-rules/rules.neon
+	- vendor/ergebnis/phpstan-rules/rules.neon
 ```
 
 :bulb: You probably want to use these rules on top of the rules provided by:
@@ -38,28 +38,28 @@ includes:
 
 This package provides the following rules for use with [`phpstan/phpstan`](https://github.com/phpstan/phpstan):
 
-* [`Localheinz\PHPStan\Rules\Classes\FinalRule`](https://github.com/localheinz/phpstan-rules#classesfinalrule)
-* [`Localheinz\PHPStan\Rules\Classes\NoExtendsRule`](https://github.com/localheinz/phpstan-rules#classesnoextendsrule)
-* [`Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#closuresnonullablereturntypedeclarationrule)
-* [`Localheinz\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#closuresnoparameterwithnullabletypedeclarationrule)
-* [`Localheinz\PHPStan\Rules\Closures\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#closuresnoparameterwithnulldefaultvaluerule)
-* [`Localheinz\PHPStan\Rules\Expressions\NoCompactRule`](https://github.com/localheinz/phpstan-rules#expressionsnocompactrule)
-* [`Localheinz\PHPStan\Rules\Expressions\NoEmptyRule`](https://github.com/localheinz/phpstan-rules#expressionsnoemptyrule)
-* [`Localheinz\PHPStan\Rules\Expressions\NoErrorSuppressionRule`](https://github.com/localheinz/phpstan-rules#expressionserrorsuppressionrule)
-* [`Localheinz\PHPStan\Rules\Expressions\NoEvalRule`](https://github.com/localheinz/phpstan-rules#expressionsnoevalrule)
-* [`Localheinz\PHPStan\Rules\Expressions\NoIssetRule`](https://github.com/localheinz/phpstan-rules#expressionsnoissetrule)
-* [`Localheinz\PHPStan\Rules\Files\DeclareStrictTypesRule`](https://github.com/localheinz/phpstan-rules#filesdeclarestricttypesrule)
-* [`Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#functionsnonullablereturntypedeclarationrule)
-* [`Localheinz\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclaration`](https://github.com/localheinz/phpstan-rules#functionsnoparameterwithnullabletypedeclarationrule)
-* [`Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#functionsnoparameterwithnulldefaultvaluerule)
-* [`Localheinz\PHPStan\Rules\Methods\FinalInAbstractClassRule`](https://github.com/localheinz/phpstan-rules#methodsfinalinabstractclassrule)
-* [`Localheinz\PHPStan\Rules\Methods\NoConstructorParameterWithDefaultValueRule`](https://github.com/localheinz/phpstan-rules#methodsnoconstructorparameterwithdefaultvaluerule)
-* [`Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnonullablereturntypedeclarationrule)
-* [`Localheinz\PHPStan\Rules\Methods\NoParameterWithContainerTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnoparameterwithcontainertypedeclarationrule)
-* [`Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnoparameterwithnullabletypedeclarationrule)
-* [`Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#methodsnoparameterwithnulldefaultvaluerule)
-* [`Localheinz\PHPStan\Rules\Methods\PrivateInFinalClassRule`](https://github.com/localheinz/phpstan-rules#methodsprivateinfinalclassrule)
-* [`Localheinz\PHPStan\Rules\Statements\NoSwitchRule`](https://github.com/localheinz/phpstan-rules#statementsnoswitchrule)
+* [`Ergebnis\PHPStan\Rules\Classes\FinalRule`](https://github.com/ergebnis/phpstan-rules#classesfinalrule)
+* [`Ergebnis\PHPStan\Rules\Classes\NoExtendsRule`](https://github.com/ergebnis/phpstan-rules#classesnoextendsrule)
+* [`Ergebnis\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule`](https://github.com/ergebnis/phpstan-rules#closuresnonullablereturntypedeclarationrule)
+* [`Ergebnis\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule`](https://github.com/ergebnis/phpstan-rules#closuresnoparameterwithnullabletypedeclarationrule)
+* [`Ergebnis\PHPStan\Rules\Closures\NoParameterWithNullDefaultValueRule`](https://github.com/ergebnis/phpstan-rules#closuresnoparameterwithnulldefaultvaluerule)
+* [`Ergebnis\PHPStan\Rules\Expressions\NoCompactRule`](https://github.com/ergebnis/phpstan-rules#expressionsnocompactrule)
+* [`Ergebnis\PHPStan\Rules\Expressions\NoEmptyRule`](https://github.com/ergebnis/phpstan-rules#expressionsnoemptyrule)
+* [`Ergebnis\PHPStan\Rules\Expressions\NoErrorSuppressionRule`](https://github.com/ergebnis/phpstan-rules#expressionserrorsuppressionrule)
+* [`Ergebnis\PHPStan\Rules\Expressions\NoEvalRule`](https://github.com/ergebnis/phpstan-rules#expressionsnoevalrule)
+* [`Ergebnis\PHPStan\Rules\Expressions\NoIssetRule`](https://github.com/ergebnis/phpstan-rules#expressionsnoissetrule)
+* [`Ergebnis\PHPStan\Rules\Files\DeclareStrictTypesRule`](https://github.com/ergebnis/phpstan-rules#filesdeclarestricttypesrule)
+* [`Ergebnis\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule`](https://github.com/ergebnis/phpstan-rules#functionsnonullablereturntypedeclarationrule)
+* [`Ergebnis\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclaration`](https://github.com/ergebnis/phpstan-rules#functionsnoparameterwithnullabletypedeclarationrule)
+* [`Ergebnis\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule`](https://github.com/ergebnis/phpstan-rules#functionsnoparameterwithnulldefaultvaluerule)
+* [`Ergebnis\PHPStan\Rules\Methods\FinalInAbstractClassRule`](https://github.com/ergebnis/phpstan-rules#methodsfinalinabstractclassrule)
+* [`Ergebnis\PHPStan\Rules\Methods\NoConstructorParameterWithDefaultValueRule`](https://github.com/ergebnis/phpstan-rules#methodsnoconstructorparameterwithdefaultvaluerule)
+* [`Ergebnis\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule`](https://github.com/ergebnis/phpstan-rules#methodsnonullablereturntypedeclarationrule)
+* [`Ergebnis\PHPStan\Rules\Methods\NoParameterWithContainerTypeDeclarationRule`](https://github.com/ergebnis/phpstan-rules#methodsnoparameterwithcontainertypedeclarationrule)
+* [`Ergebnis\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule`](https://github.com/ergebnis/phpstan-rules#methodsnoparameterwithnullabletypedeclarationrule)
+* [`Ergebnis\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule`](https://github.com/ergebnis/phpstan-rules#methodsnoparameterwithnulldefaultvaluerule)
+* [`Ergebnis\PHPStan\Rules\Methods\PrivateInFinalClassRule`](https://github.com/ergebnis/phpstan-rules#methodsprivateinfinalclassrule)
+* [`Ergebnis\PHPStan\Rules\Statements\NoSwitchRule`](https://github.com/ergebnis/phpstan-rules#statementsnoswitchrule)
 
 ### Classes
 
@@ -106,7 +106,7 @@ If you want to allow additional classes to be extended, you can set the `classes
 ```neon
 parameters:
 	classesAllowedToBeExtended:
-		- Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase
+		- Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase
 		- PHPStan\Testing\RuleTestCase
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "localheinz/phpstan-rules",
+  "name": "ergebnis/phpstan-rules",
   "type": "phpstan-extension",
   "description": "Provides additional rules for phpstan/phpstan.",
   "keywords": [
@@ -7,7 +7,7 @@
     "phpstan-rules",
     "phpstan-extreme-rules"
   ],
-  "homepage": "https://github.com/localheinz/phpstan-rules",
+  "homepage": "https://github.com/ergebnis/phpstan-rules",
   "license": "MIT",
   "authors": [
     {
@@ -20,6 +20,9 @@
     "ext-mbstring": "*",
     "nikic/php-parser": "^4.2.3",
     "phpstan/phpstan": "~0.11.15 || ~0.12.0"
+  },
+  "replace": {
+    "localheinz/phpstan-rules": "*"
   },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.1.0",
@@ -46,16 +49,16 @@
   },
   "autoload": {
     "psr-4": {
-      "Localheinz\\PHPStan\\Rules\\": "src/"
+      "Ergebnis\\PHPStan\\Rules\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Localheinz\\PHPStan\\Rules\\Test\\": "test/"
+      "Ergebnis\\PHPStan\\Rules\\Test\\": "test/"
     }
   },
   "support": {
-    "issues": "https://github.com/localheinz/phpstan-rules/issues",
-    "source": "https://github.com/localheinz/phpstan-rules"
+    "issues": "https://github.com/ergebnis/phpstan-rules/issues",
+    "source": "https://github.com/ergebnis/phpstan-rules"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "86cf242d470402407a67acd1f36005f9",
+    "content-hash": "0177864a9adb8a2186532b971d015000",
     "packages": [
         {
             "name": "composer/xdebug-handler",
@@ -4580,8 +4580,8 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,7 +4,7 @@ includes:
 
 parameters:
 	classesAllowedToBeExtended:
-		- Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase
+		- Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase
 		- PHPStan\Testing\RuleTestCase
 	excludes_analyse:
 		- %currentWorkingDirectory%/test/Fixture/

--- a/rules.neon
+++ b/rules.neon
@@ -12,42 +12,42 @@ parametersSchema:
 	interfacesImplementedByContainers: listOf(string())
 
 rules:
-	- Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule
-	- Localheinz\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule
-	- Localheinz\PHPStan\Rules\Expressions\NoCompactRule
-	- Localheinz\PHPStan\Rules\Expressions\NoEmptyRule
-	- Localheinz\PHPStan\Rules\Expressions\NoErrorSuppressionRule
-	- Localheinz\PHPStan\Rules\Expressions\NoEvalRule
-	- Localheinz\PHPStan\Rules\Expressions\NoIssetRule
-	- Localheinz\PHPStan\Rules\Files\DeclareStrictTypesRule
-	- Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule
-	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclarationRule
-	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule
-	- Localheinz\PHPStan\Rules\Methods\FinalInAbstractClassRule
-	- Localheinz\PHPStan\Rules\Methods\NoConstructorParameterWithDefaultValueRule
-	- Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule
-	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule
-	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule
-	- Localheinz\PHPStan\Rules\Methods\PrivateInFinalClassRule
-	- Localheinz\PHPStan\Rules\Statements\NoSwitchRule
+	- Ergebnis\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule
+	- Ergebnis\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule
+	- Ergebnis\PHPStan\Rules\Expressions\NoCompactRule
+	- Ergebnis\PHPStan\Rules\Expressions\NoEmptyRule
+	- Ergebnis\PHPStan\Rules\Expressions\NoErrorSuppressionRule
+	- Ergebnis\PHPStan\Rules\Expressions\NoEvalRule
+	- Ergebnis\PHPStan\Rules\Expressions\NoIssetRule
+	- Ergebnis\PHPStan\Rules\Files\DeclareStrictTypesRule
+	- Ergebnis\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule
+	- Ergebnis\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclarationRule
+	- Ergebnis\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule
+	- Ergebnis\PHPStan\Rules\Methods\FinalInAbstractClassRule
+	- Ergebnis\PHPStan\Rules\Methods\NoConstructorParameterWithDefaultValueRule
+	- Ergebnis\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule
+	- Ergebnis\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule
+	- Ergebnis\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule
+	- Ergebnis\PHPStan\Rules\Methods\PrivateInFinalClassRule
+	- Ergebnis\PHPStan\Rules\Statements\NoSwitchRule
 
 services:
 	-
-		class: Localheinz\PHPStan\Rules\Classes\FinalRule
+		class: Ergebnis\PHPStan\Rules\Classes\FinalRule
 		arguments:
 			allowAbstractClasses: %allowAbstractClasses%
 			classesNotRequiredToBeAbstractOrFinal: %classesNotRequiredToBeAbstractOrFinal%
 		tags:
 			- phpstan.rules.rule
 	-
-		class: Localheinz\PHPStan\Rules\Classes\NoExtendsRule
+		class: Ergebnis\PHPStan\Rules\Classes\NoExtendsRule
 		arguments:
 			classesAllowedToBeExtended: %classesAllowedToBeExtended%
 		tags:
 			- phpstan.rules.rule
 
 	-
-		class: Localheinz\PHPStan\Rules\Methods\NoParameterWithContainerTypeDeclarationRule
+		class: Ergebnis\PHPStan\Rules\Methods\NoParameterWithContainerTypeDeclarationRule
 		arguments:
 			interfacesImplementedByContainers: %interfacesImplementedByContainers%
 		tags:

--- a/src/Classes/FinalRule.php
+++ b/src/Classes/FinalRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Classes;
+namespace Ergebnis\PHPStan\Rules\Classes;
 
 use PhpParser\Comment;
 use PhpParser\Node;

--- a/src/Classes/NoExtendsRule.php
+++ b/src/Classes/NoExtendsRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Classes;
+namespace Ergebnis\PHPStan\Rules\Classes;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/Closures/NoNullableReturnTypeDeclarationRule.php
+++ b/src/Closures/NoNullableReturnTypeDeclarationRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Closures;
+namespace Ergebnis\PHPStan\Rules\Closures;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/Closures/NoParameterWithNullDefaultValueRule.php
+++ b/src/Closures/NoParameterWithNullDefaultValueRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Closures;
+namespace Ergebnis\PHPStan\Rules\Closures;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/Closures/NoParameterWithNullableTypeDeclarationRule.php
+++ b/src/Closures/NoParameterWithNullableTypeDeclarationRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Closures;
+namespace Ergebnis\PHPStan\Rules\Closures;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/Expressions/NoCompactRule.php
+++ b/src/Expressions/NoCompactRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Expressions;
+namespace Ergebnis\PHPStan\Rules\Expressions;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/Expressions/NoEmptyRule.php
+++ b/src/Expressions/NoEmptyRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Expressions;
+namespace Ergebnis\PHPStan\Rules\Expressions;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/Expressions/NoErrorSuppressionRule.php
+++ b/src/Expressions/NoErrorSuppressionRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Expressions;
+namespace Ergebnis\PHPStan\Rules\Expressions;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/Expressions/NoEvalRule.php
+++ b/src/Expressions/NoEvalRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Expressions;
+namespace Ergebnis\PHPStan\Rules\Expressions;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/Expressions/NoIssetRule.php
+++ b/src/Expressions/NoIssetRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Expressions;
+namespace Ergebnis\PHPStan\Rules\Expressions;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/Files/DeclareStrictTypesRule.php
+++ b/src/Files/DeclareStrictTypesRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Files;
+namespace Ergebnis\PHPStan\Rules\Files;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/Functions/NoNullableReturnTypeDeclarationRule.php
+++ b/src/Functions/NoNullableReturnTypeDeclarationRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Functions;
+namespace Ergebnis\PHPStan\Rules\Functions;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/Functions/NoParameterWithNullDefaultValueRule.php
+++ b/src/Functions/NoParameterWithNullDefaultValueRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Functions;
+namespace Ergebnis\PHPStan\Rules\Functions;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/Functions/NoParameterWithNullableTypeDeclarationRule.php
+++ b/src/Functions/NoParameterWithNullableTypeDeclarationRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Functions;
+namespace Ergebnis\PHPStan\Rules\Functions;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/Methods/FinalInAbstractClassRule.php
+++ b/src/Methods/FinalInAbstractClassRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Methods;
+namespace Ergebnis\PHPStan\Rules\Methods;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/Methods/NoConstructorParameterWithDefaultValueRule.php
+++ b/src/Methods/NoConstructorParameterWithDefaultValueRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Methods;
+namespace Ergebnis\PHPStan\Rules\Methods;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/Methods/NoNullableReturnTypeDeclarationRule.php
+++ b/src/Methods/NoNullableReturnTypeDeclarationRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Methods;
+namespace Ergebnis\PHPStan\Rules\Methods;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/Methods/NoParameterWithContainerTypeDeclarationRule.php
+++ b/src/Methods/NoParameterWithContainerTypeDeclarationRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Methods;
+namespace Ergebnis\PHPStan\Rules\Methods;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/Methods/NoParameterWithNullDefaultValueRule.php
+++ b/src/Methods/NoParameterWithNullDefaultValueRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Methods;
+namespace Ergebnis\PHPStan\Rules\Methods;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/Methods/NoParameterWithNullableTypeDeclarationRule.php
+++ b/src/Methods/NoParameterWithNullableTypeDeclarationRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Methods;
+namespace Ergebnis\PHPStan\Rules\Methods;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/Methods/PrivateInFinalClassRule.php
+++ b/src/Methods/PrivateInFinalClassRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Methods;
+namespace Ergebnis\PHPStan\Rules\Methods;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/src/Statements/NoSwitchRule.php
+++ b/src/Statements/NoSwitchRule.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Statements;
+namespace Ergebnis\PHPStan\Rules\Statements;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\AutoReview;
+namespace Ergebnis\PHPStan\Rules\Test\AutoReview;
 
 use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
@@ -29,8 +29,8 @@ final class SrcCodeTest extends Framework\TestCase
     {
         self::assertClassesHaveTests(
             __DIR__ . '/../../src',
-            'Localheinz\\PHPStan\\Rules\\',
-            'Localheinz\\PHPStan\\Rules\\Test\\Integration\\'
+            'Ergebnis\\PHPStan\\Rules\\',
+            'Ergebnis\\PHPStan\\Rules\\Test\\Integration\\'
         );
     }
 }

--- a/test/AutoReview/TestCodeTest.php
+++ b/test/AutoReview/TestCodeTest.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\AutoReview;
+namespace Ergebnis\PHPStan\Rules\Test\AutoReview;
 
+use Ergebnis\PHPStan\Rules\Test\Integration;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\PHPStan\Rules\Test\Integration;
 use PHPUnit\Framework;
 
 /**

--- a/test/Fixture/Classes/FinalRule/Failure/AbstractClass.php
+++ b/test/Fixture/Classes/FinalRule/Failure/AbstractClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Failure;
 
 abstract class AbstractClass
 {

--- a/test/Fixture/Classes/FinalRule/Failure/NeitherAbstractNorFinalClass.php
+++ b/test/Fixture/Classes/FinalRule/Failure/NeitherAbstractNorFinalClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Failure;
 
 class NeitherAbstractNorFinalClass
 {

--- a/test/Fixture/Classes/FinalRule/Failure/NonFinalClassWithoutEntityAnnotationInInlineDocBlock.php
+++ b/test/Fixture/Classes/FinalRule/Failure/NonFinalClassWithoutEntityAnnotationInInlineDocBlock.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Failure;
 
 /** @eNtItY */
 class NonFinalClassWithoutEntityAnnotationInInlineDocBlock

--- a/test/Fixture/Classes/FinalRule/Failure/NonFinalClassWithoutEntityAnnotationInMultilineDocBlock.php
+++ b/test/Fixture/Classes/FinalRule/Failure/NonFinalClassWithoutEntityAnnotationInMultilineDocBlock.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Failure;
 
 /**
  * @Table(name="hmm")

--- a/test/Fixture/Classes/FinalRule/Failure/NonFinalClassWithoutOrmEntityAnnotationInInlineDocBlock.php
+++ b/test/Fixture/Classes/FinalRule/Failure/NonFinalClassWithoutOrmEntityAnnotationInInlineDocBlock.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Failure;
 
 /** @OrM\eNtItY */
 class NonFinalClassWithoutOrmEntityAnnotationInInlineDocBlock

--- a/test/Fixture/Classes/FinalRule/Failure/NonFinalClassWithoutOrmEntityAnnotationInMultilineDocBlock.php
+++ b/test/Fixture/Classes/FinalRule/Failure/NonFinalClassWithoutOrmEntityAnnotationInMultilineDocBlock.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Failure;
 
 /**
  * @ORM\Table(name="hmm")

--- a/test/Fixture/Classes/FinalRule/Success/ExampleInterface.php
+++ b/test/Fixture/Classes/FinalRule/Success/ExampleInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
 
 interface ExampleInterface
 {

--- a/test/Fixture/Classes/FinalRule/Success/ExampleTrait.php
+++ b/test/Fixture/Classes/FinalRule/Success/ExampleTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
 
 trait ExampleTrait
 {

--- a/test/Fixture/Classes/FinalRule/Success/FinalClass.php
+++ b/test/Fixture/Classes/FinalRule/Success/FinalClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
 
 final class FinalClass
 {

--- a/test/Fixture/Classes/FinalRule/Success/FinalClassWithAnonymousClass.php
+++ b/test/Fixture/Classes/FinalRule/Success/FinalClassWithAnonymousClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
 
 final class FinalClassWithAnonymousClass
 {

--- a/test/Fixture/Classes/FinalRule/Success/NonFinalClassWithEntityAnnotationInInlineDocBlock.php
+++ b/test/Fixture/Classes/FinalRule/Success/NonFinalClassWithEntityAnnotationInInlineDocBlock.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
 
 /** @Entity */
 class NonFinalClassWithEntityAnnotationInInlineDocBlock

--- a/test/Fixture/Classes/FinalRule/Success/NonFinalClassWithEntityAnnotationInMultilineDocBlock.php
+++ b/test/Fixture/Classes/FinalRule/Success/NonFinalClassWithEntityAnnotationInMultilineDocBlock.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
 
 /**
  * @Table(name="hmm")

--- a/test/Fixture/Classes/FinalRule/Success/NonFinalClassWithOrmEntityAnnotationInInlineDocBlock.php
+++ b/test/Fixture/Classes/FinalRule/Success/NonFinalClassWithOrmEntityAnnotationInInlineDocBlock.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
 
 /** @ORM\Entity */
 class NonFinalClassWithOrmEntityAnnotationInInlineDocBlock

--- a/test/Fixture/Classes/FinalRule/Success/NonFinalClassWithOrmEntityAnnotationInMultilineDocBlock.php
+++ b/test/Fixture/Classes/FinalRule/Success/NonFinalClassWithOrmEntityAnnotationInMultilineDocBlock.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
 
 /**
  * @ORM\Table(name="hmm")

--- a/test/Fixture/Classes/FinalRule/Success/TraitWithAnonymousClass.php
+++ b/test/Fixture/Classes/FinalRule/Success/TraitWithAnonymousClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
 
 trait TraitWithAnonymousClass
 {

--- a/test/Fixture/Classes/FinalRule/Success/anonymous-class.php
+++ b/test/Fixture/Classes/FinalRule/Success/anonymous-class.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
 
 $foo = new class() {
     public function __toString(): string

--- a/test/Fixture/Classes/FinalRuleWithAbstractClassesAllowed/Failure/AbstractClass.php
+++ b/test/Fixture/Classes/FinalRuleWithAbstractClassesAllowed/Failure/AbstractClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithAbstractClassesAllowed\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithAbstractClassesAllowed\Failure;
 
 abstract class AbstractClass
 {

--- a/test/Fixture/Classes/FinalRuleWithAbstractClassesAllowed/Failure/NeitherAbstractNorFinalClass.php
+++ b/test/Fixture/Classes/FinalRuleWithAbstractClassesAllowed/Failure/NeitherAbstractNorFinalClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithAbstractClassesAllowed\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithAbstractClassesAllowed\Failure;
 
 class NeitherAbstractNorFinalClass
 {

--- a/test/Fixture/Classes/FinalRuleWithAbstractClassesAllowed/Success/ExampleInterface.php
+++ b/test/Fixture/Classes/FinalRuleWithAbstractClassesAllowed/Success/ExampleInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithAbstractClassesAllowed\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithAbstractClassesAllowed\Success;
 
 interface ExampleInterface
 {

--- a/test/Fixture/Classes/FinalRuleWithAbstractClassesAllowed/Success/ExampleTrait.php
+++ b/test/Fixture/Classes/FinalRuleWithAbstractClassesAllowed/Success/ExampleTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithAbstractClassesAllowed\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithAbstractClassesAllowed\Success;
 
 trait ExampleTrait
 {

--- a/test/Fixture/Classes/FinalRuleWithAbstractClassesAllowed/Success/FinalClass.php
+++ b/test/Fixture/Classes/FinalRuleWithAbstractClassesAllowed/Success/FinalClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithAbstractClassesAllowed\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithAbstractClassesAllowed\Success;
 
 final class FinalClass
 {

--- a/test/Fixture/Classes/FinalRuleWithAbstractClassesAllowed/Success/FinalClassWithAnonymousClass.php
+++ b/test/Fixture/Classes/FinalRuleWithAbstractClassesAllowed/Success/FinalClassWithAnonymousClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithAbstractClassesAllowed\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithAbstractClassesAllowed\Success;
 
 final class FinalClassWithAnonymousClass
 {

--- a/test/Fixture/Classes/FinalRuleWithAbstractClassesAllowed/Success/TraitWithAnonymousClass.php
+++ b/test/Fixture/Classes/FinalRuleWithAbstractClassesAllowed/Success/TraitWithAnonymousClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithAbstractClassesAllowed\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithAbstractClassesAllowed\Success;
 
 trait TraitWithAnonymousClass
 {

--- a/test/Fixture/Classes/FinalRuleWithAbstractClassesAllowed/Success/anonymous-class.php
+++ b/test/Fixture/Classes/FinalRuleWithAbstractClassesAllowed/Success/anonymous-class.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithAbstractClassesAllowed\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithAbstractClassesAllowed\Success;
 
 $foo = new class() {
     public function __toString(): string

--- a/test/Fixture/Classes/FinalRuleWithExcludedClassNames/Failure/AbstractClass.php
+++ b/test/Fixture/Classes/FinalRuleWithExcludedClassNames/Failure/AbstractClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithExcludedClassNames\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithExcludedClassNames\Failure;
 
 abstract class AbstractClass
 {

--- a/test/Fixture/Classes/FinalRuleWithExcludedClassNames/Failure/NeitherAbstractNorFinalClass.php
+++ b/test/Fixture/Classes/FinalRuleWithExcludedClassNames/Failure/NeitherAbstractNorFinalClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithExcludedClassNames\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithExcludedClassNames\Failure;
 
 class NeitherAbstractNorFinalClass
 {

--- a/test/Fixture/Classes/FinalRuleWithExcludedClassNames/Success/ExampleInterface.php
+++ b/test/Fixture/Classes/FinalRuleWithExcludedClassNames/Success/ExampleInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithExcludedClassNames\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithExcludedClassNames\Success;
 
 interface ExampleInterface
 {

--- a/test/Fixture/Classes/FinalRuleWithExcludedClassNames/Success/ExampleTrait.php
+++ b/test/Fixture/Classes/FinalRuleWithExcludedClassNames/Success/ExampleTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithExcludedClassNames\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithExcludedClassNames\Success;
 
 trait ExampleTrait
 {

--- a/test/Fixture/Classes/FinalRuleWithExcludedClassNames/Success/FinalClass.php
+++ b/test/Fixture/Classes/FinalRuleWithExcludedClassNames/Success/FinalClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithExcludedClassNames\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithExcludedClassNames\Success;
 
 final class FinalClass
 {

--- a/test/Fixture/Classes/FinalRuleWithExcludedClassNames/Success/FinalClassWithAnonymousClass.php
+++ b/test/Fixture/Classes/FinalRuleWithExcludedClassNames/Success/FinalClassWithAnonymousClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithExcludedClassNames\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithExcludedClassNames\Success;
 
 final class FinalClassWithAnonymousClass
 {

--- a/test/Fixture/Classes/FinalRuleWithExcludedClassNames/Success/NeitherAbstractNorFinalClassButWhitelisted.php
+++ b/test/Fixture/Classes/FinalRuleWithExcludedClassNames/Success/NeitherAbstractNorFinalClassButWhitelisted.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithExcludedClassNames\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithExcludedClassNames\Success;
 
 class NeitherAbstractNorFinalClassButWhitelisted
 {

--- a/test/Fixture/Classes/FinalRuleWithExcludedClassNames/Success/TraitWithAnonymousClass.php
+++ b/test/Fixture/Classes/FinalRuleWithExcludedClassNames/Success/TraitWithAnonymousClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithExcludedClassNames\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithExcludedClassNames\Success;
 
 trait TraitWithAnonymousClass
 {

--- a/test/Fixture/Classes/FinalRuleWithExcludedClassNames/Success/anonymous-class.php
+++ b/test/Fixture/Classes/FinalRuleWithExcludedClassNames/Success/anonymous-class.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithExcludedClassNames\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRuleWithExcludedClassNames\Success;
 
 $foo = new class() {
     public function __toString(): string

--- a/test/Fixture/Classes/NoExtendsRule/Failure/ClassExtendingOtherClass.php
+++ b/test/Fixture/Classes/NoExtendsRule/Failure/ClassExtendingOtherClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Failure;
 
 final class ClassExtendingOtherClass extends OtherClass
 {

--- a/test/Fixture/Classes/NoExtendsRule/Failure/OtherClass.php
+++ b/test/Fixture/Classes/NoExtendsRule/Failure/OtherClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Failure;
 
 class OtherClass
 {

--- a/test/Fixture/Classes/NoExtendsRule/Failure/anonymous-class-extending-other-class.php
+++ b/test/Fixture/Classes/NoExtendsRule/Failure/anonymous-class-extending-other-class.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Failure;
 
 $foo = new class() extends OtherClass {
     public function __toString(): string

--- a/test/Fixture/Classes/NoExtendsRule/Success/ClassExtendingPhpUnitFrameworkTestCase.php
+++ b/test/Fixture/Classes/NoExtendsRule/Success/ClassExtendingPhpUnitFrameworkTestCase.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Success;
 
 use PHPUnit\Framework\TestCase;
 

--- a/test/Fixture/Classes/NoExtendsRule/Success/ExampleClass.php
+++ b/test/Fixture/Classes/NoExtendsRule/Success/ExampleClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Success;
 
 final class ExampleClass
 {

--- a/test/Fixture/Classes/NoExtendsRule/Success/ExampleInterface.php
+++ b/test/Fixture/Classes/NoExtendsRule/Success/ExampleInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Success;
 
 interface ExampleInterface
 {

--- a/test/Fixture/Classes/NoExtendsRule/Success/InterfaceExtendingOtherInterface.php
+++ b/test/Fixture/Classes/NoExtendsRule/Success/InterfaceExtendingOtherInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Success;
 
 interface InterfaceExtendingOtherInterface extends OtherInterface
 {

--- a/test/Fixture/Classes/NoExtendsRule/Success/OtherInterface.php
+++ b/test/Fixture/Classes/NoExtendsRule/Success/OtherInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Success;
 
 interface OtherInterface
 {

--- a/test/Fixture/Classes/NoExtendsRule/Success/anonymous-class.php
+++ b/test/Fixture/Classes/NoExtendsRule/Success/anonymous-class.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Success;
 
 $foo = new class() {
     public function __toString(): string

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Failure/ClassExtendingOtherClass.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Failure/ClassExtendingOtherClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Failure;
 
 final class ClassExtendingOtherClass extends OtherClass
 {

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Failure/OtherClass.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Failure/OtherClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Failure;
 
 class OtherClass
 {

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Failure/anonymous-class-extending-other-class.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Failure/anonymous-class-extending-other-class.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Failure;
 
 $foo = new class() extends OtherClass {
     public function __toString(): string

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ClassAllowedToBeExtended.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ClassAllowedToBeExtended.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
 
 class ClassAllowedToBeExtended
 {

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ClassExtendingClassAllowedToBeExtended.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ClassExtendingClassAllowedToBeExtended.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
 
 final class ClassExtendingClassAllowedToBeExtended extends ClassAllowedToBeExtended
 {

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ClassExtendingPhpUnitFrameworkTestCase.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ClassExtendingPhpUnitFrameworkTestCase.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
 
 use PHPUnit\Framework\TestCase;
 

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ExampleClass.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ExampleClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
 
 final class ExampleClass
 {

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ExampleInterface.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ExampleInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
 
 interface ExampleInterface
 {

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/InterfaceExtendingOtherInterface.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/InterfaceExtendingOtherInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
 
 interface InterfaceExtendingOtherInterface extends OtherInterface
 {

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/OtherInterface.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/OtherInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
 
 interface OtherInterface
 {

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/anonymous-class-extending-class-allowed-to-be-extended.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/anonymous-class-extending-class-allowed-to-be-extended.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
 
 $foo = new class() extends ClassAllowedToBeExtended {
     public function __toString(): string

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/anonymous-class.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/anonymous-class.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
 
 $foo = new class() {
     public function __toString(): string

--- a/test/Fixture/Closures/NoNullableReturnTypeDeclarationRule/Failure/closure-with-nullable-return-type-declaration.php
+++ b/test/Fixture/Closures/NoNullableReturnTypeDeclarationRule/Failure/closure-with-nullable-return-type-declaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Closures\NoNullableReturnTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Closures\NoNullableReturnTypeDeclarationRule\Failure;
 
 $foo = function (): ?string {
     return 'Hello';

--- a/test/Fixture/Closures/NoNullableReturnTypeDeclarationRule/Success/closure-with-return-type-declaration.php
+++ b/test/Fixture/Closures/NoNullableReturnTypeDeclarationRule/Success/closure-with-return-type-declaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Closures\NoNullableReturnTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Closures\NoNullableReturnTypeDeclarationRule\Success;
 
 $foo = function (): string {
     return 'Hello';

--- a/test/Fixture/Closures/NoNullableReturnTypeDeclarationRule/Success/closure-without-return-type-declaration.php
+++ b/test/Fixture/Closures/NoNullableReturnTypeDeclarationRule/Success/closure-without-return-type-declaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Closures\NoNullableReturnTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Closures\NoNullableReturnTypeDeclarationRule\Success;
 
 $foo = function () {
     return 'Hello';

--- a/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Failure/closure-with-parameter-with-null-default-value.php
+++ b/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Failure/closure-with-parameter-with-null-default-value.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
 
 $foo = function ($bar = null) {
     return $bar;

--- a/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Failure/closure-with-parameter-with-root-namespace-referenced-null-default-value.php
+++ b/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Failure/closure-with-parameter-with-root-namespace-referenced-null-default-value.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
 
 $foo = function ($bar = null) {
     return $bar;

--- a/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Failure/closure-with-parameter-with-wrongly-capitalized-null-default-value.php
+++ b/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Failure/closure-with-parameter-with-wrongly-capitalized-null-default-value.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
 
 $foo = function ($bar = null) {
     return $bar;

--- a/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Success/closure-with-parameter-with-non-null-default-value.php
+++ b/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Success/closure-with-parameter-with-non-null-default-value.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
 
 $foo = function ($bar = true) {
     return $bar;

--- a/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Success/closure-with-parameter-without-default-value.php
+++ b/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Success/closure-with-parameter-without-default-value.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
 
 $foo = function ($bar) {
     return $bar;

--- a/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Success/closure-without-parameters.php
+++ b/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Success/closure-without-parameters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
 
 $foo = function (): void {
 };

--- a/test/Fixture/Closures/NoParameterWithNullableTypeDeclarationRule/Failure/closure-with-parameter-with-nullable-type-declaration.php
+++ b/test/Fixture/Closures/NoParameterWithNullableTypeDeclarationRule/Failure/closure-with-parameter-with-nullable-type-declaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
 
 $foo = function (?string $bar) {
     return $bar;

--- a/test/Fixture/Closures/NoParameterWithNullableTypeDeclarationRule/Success/closure-with-parameter-with-type-declaration.php
+++ b/test/Fixture/Closures/NoParameterWithNullableTypeDeclarationRule/Success/closure-with-parameter-with-type-declaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
 
 $foo = function (string $bar) {
     return $bar;

--- a/test/Fixture/Closures/NoParameterWithNullableTypeDeclarationRule/Success/closure-with-parameter-without-type-declaration.php
+++ b/test/Fixture/Closures/NoParameterWithNullableTypeDeclarationRule/Success/closure-with-parameter-without-type-declaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
 
 $foo = function ($bar) {
     return $bar;

--- a/test/Fixture/Closures/NoParameterWithNullableTypeDeclarationRule/Success/closure-without-parameters.php
+++ b/test/Fixture/Closures/NoParameterWithNullableTypeDeclarationRule/Success/closure-without-parameters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
 
 $foo = function (): void {
 };

--- a/test/Fixture/Expressions/NoCompactRule/Failure/compact-used-with-alias.php
+++ b/test/Fixture/Expressions/NoCompactRule/Failure/compact-used-with-alias.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoCompactRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Expressions\NoCompactRule\Failure;
 
 use function compact as compress;
 

--- a/test/Fixture/Expressions/NoCompactRule/Failure/compact-used-with-correct-case.php
+++ b/test/Fixture/Expressions/NoCompactRule/Failure/compact-used-with-correct-case.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoCompactRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Expressions\NoCompactRule\Failure;
 
 $foo = 9000;
 $bar = 42;

--- a/test/Fixture/Expressions/NoCompactRule/Failure/compact-used-with-incorrect-case.php
+++ b/test/Fixture/Expressions/NoCompactRule/Failure/compact-used-with-incorrect-case.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoCompactRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Expressions\NoCompactRule\Failure;
 
 $foo = 9000;
 $bar = 42;

--- a/test/Fixture/Expressions/NoCompactRule/Success/compact-not-used.php
+++ b/test/Fixture/Expressions/NoCompactRule/Success/compact-not-used.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoEmptyRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Expressions\NoEmptyRule\Success;
 
 function _compact(string ...$names): array
 {

--- a/test/Fixture/Expressions/NoEmptyRule/Failure/empty-used-with-correct-case.php
+++ b/test/Fixture/Expressions/NoEmptyRule/Failure/empty-used-with-correct-case.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoEmptyRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Expressions\NoEmptyRule\Failure;
 
 if (empty($foo)) {
     echo 'Hello!';

--- a/test/Fixture/Expressions/NoEmptyRule/Failure/empty-used-with-incorrect-case.php
+++ b/test/Fixture/Expressions/NoEmptyRule/Failure/empty-used-with-incorrect-case.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoEmptuRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Expressions\NoEmptuRule\Failure;
 
 if (eMpTy($foo)) {
     echo 'Hello!';

--- a/test/Fixture/Expressions/NoEmptyRule/Success/empty-not-used.php
+++ b/test/Fixture/Expressions/NoEmptyRule/Success/empty-not-used.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoEmptyRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Expressions\NoEmptyRule\Success;
 
 function _empty(): bool
 {

--- a/test/Fixture/Expressions/NoErrorSuppressionRule/Failure/error-suppression-used.php
+++ b/test/Fixture/Expressions/NoErrorSuppressionRule/Failure/error-suppression-used.php
@@ -2,6 +2,6 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoErrorSuppressionRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Expressions\NoErrorSuppressionRule\Failure;
 
 @\serialize($value);

--- a/test/Fixture/Expressions/NoErrorSuppressionRule/Success/error-suppression-not-used.php
+++ b/test/Fixture/Expressions/NoErrorSuppressionRule/Success/error-suppression-not-used.php
@@ -2,6 +2,6 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoErrorSuppressionRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Expressions\NoErrorSuppressionRule\Success;
 
 \serialize($value);

--- a/test/Fixture/Expressions/NoEvalRule/Failure/eval-used-with-correct-case.php
+++ b/test/Fixture/Expressions/NoEvalRule/Failure/eval-used-with-correct-case.php
@@ -2,6 +2,6 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoEvalRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Expressions\NoEvalRule\Failure;
 
 eval('echo $foo');

--- a/test/Fixture/Expressions/NoEvalRule/Failure/eval-used-with-incorrect-case.php
+++ b/test/Fixture/Expressions/NoEvalRule/Failure/eval-used-with-incorrect-case.php
@@ -2,6 +2,6 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoEvalRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Expressions\NoEvalRule\Failure;
 
 eVaL('echo $foo');

--- a/test/Fixture/Expressions/NoEvalRule/Success/eval-not-used.php
+++ b/test/Fixture/Expressions/NoEvalRule/Success/eval-not-used.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoEvalRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Expressions\NoEvalRule\Success;
 
 function _eval(string $argument): void
 {

--- a/test/Fixture/Expressions/NoIssetRule/Failure/isset-used-with-correct-case.php
+++ b/test/Fixture/Expressions/NoIssetRule/Failure/isset-used-with-correct-case.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoIssetRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Expressions\NoIssetRule\Failure;
 
 if (isset($foo)) {
     echo 'Hello!';

--- a/test/Fixture/Expressions/NoIssetRule/Failure/isset-used-with-incorrect-case.php
+++ b/test/Fixture/Expressions/NoIssetRule/Failure/isset-used-with-incorrect-case.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoIssetRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Expressions\NoIssetRule\Failure;
 
 if (iSsEt($foo)) {
     echo 'Hello!';

--- a/test/Fixture/Expressions/NoIssetRule/Success/isset-not-used.php
+++ b/test/Fixture/Expressions/NoIssetRule/Success/isset-not-used.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoIssetRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Expressions\NoIssetRule\Success;
 
 function _isset(): bool
 {

--- a/test/Fixture/Files/DeclareStrictTypesRule/Failure/file-without-declare-strict-types-and-namespace-declaration.php
+++ b/test/Fixture/Files/DeclareStrictTypesRule/Failure/file-without-declare-strict-types-and-namespace-declaration.php
@@ -1,5 +1,5 @@
 <?php
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\DeclareStrictTypesRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\DeclareStrictTypesRule\Failure;
 
 echo 'Hello!';

--- a/test/Fixture/Files/DeclareStrictTypesRule/Success/file-with-comment-and-declare-strict-types-on-and-namespace-declaration.php
+++ b/test/Fixture/Files/DeclareStrictTypesRule/Success/file-with-comment-and-declare-strict-types-on-and-namespace-declaration.php
@@ -4,6 +4,6 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\DeclareStrictTypesRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\DeclareStrictTypesRule\Success;
 
 echo 'Hello!';

--- a/test/Fixture/Files/DeclareStrictTypesRule/Success/file-with-declare-strict-types-on-and-namespace-declaration.php
+++ b/test/Fixture/Files/DeclareStrictTypesRule/Success/file-with-declare-strict-types-on-and-namespace-declaration.php
@@ -2,6 +2,6 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\DeclareStrictTypesRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\DeclareStrictTypesRule\Success;
 
 echo 'Hello!';

--- a/test/Fixture/Files/DeclareStrictTypesRule/Success/file-with-doc-block-and-declare-strict-types-on-and-namespace-declaration.php
+++ b/test/Fixture/Files/DeclareStrictTypesRule/Success/file-with-doc-block-and-declare-strict-types-on-and-namespace-declaration.php
@@ -6,6 +6,6 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\DeclareStrictTypesRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\DeclareStrictTypesRule\Success;
 
 echo 'Hello!';

--- a/test/Fixture/Functions/NoNullableReturnTypeDeclarationRule/Failure/function-with-nullable-return-type-declaration.php
+++ b/test/Fixture/Functions/NoNullableReturnTypeDeclarationRule/Failure/function-with-nullable-return-type-declaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullableReturnTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoNullableReturnTypeDeclarationRule\Failure;
 
 function foo(): ?string
 {

--- a/test/Fixture/Functions/NoNullableReturnTypeDeclarationRule/Success/function-with-return-type-declaration.php
+++ b/test/Fixture/Functions/NoNullableReturnTypeDeclarationRule/Success/function-with-return-type-declaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullableReturnTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoNullableReturnTypeDeclarationRule\Success;
 
 function foo(): string
 {

--- a/test/Fixture/Functions/NoNullableReturnTypeDeclarationRule/Success/function-without-return-type-declaration.php
+++ b/test/Fixture/Functions/NoNullableReturnTypeDeclarationRule/Success/function-without-return-type-declaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullableReturnTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoNullableReturnTypeDeclarationRule\Success;
 
 function foo()
 {

--- a/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Failure/function-with-parameter-with-null-default-value.php
+++ b/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Failure/function-with-parameter-with-null-default-value.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Failure;
 
 function foo($bar = null)
 {

--- a/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Failure/function-with-parameter-with-root-namespace-referenced-null-default-value.php
+++ b/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Failure/function-with-parameter-with-root-namespace-referenced-null-default-value.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Failure;
 
 function foo($bar = \null)
 {

--- a/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Failure/function-with-parameter-with-wrongly-capitalized-null-default-value.php
+++ b/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Failure/function-with-parameter-with-wrongly-capitalized-null-default-value.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Failure;
 
 function foo($bar = nUlL)
 {

--- a/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Success/function-with-parameter-with-non-null-default-value.php
+++ b/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Success/function-with-parameter-with-non-null-default-value.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Success;
 
 function foo($bar = true)
 {

--- a/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Success/function-with-parameter-without-default-value.php
+++ b/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Success/function-with-parameter-without-default-value.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Success;
 
 function foo($bar)
 {

--- a/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Success/function-without-parameters.php
+++ b/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Success/function-without-parameters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Success;
 
 function foo(): void
 {

--- a/test/Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Failure/function-with-parameter-with-nullable-type-declaration.php
+++ b/test/Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Failure/function-with-parameter-with-nullable-type-declaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullableTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullableTypeDeclarationRule\Failure;
 
 function foo(?string $bar)
 {

--- a/test/Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Success/function-with-parameter-with-type-declaration.php
+++ b/test/Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Success/function-with-parameter-with-type-declaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullableTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullableTypeDeclarationRule\Success;
 
 function foo(string $bar)
 {

--- a/test/Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Success/function-with-parameter-without-type-declaration.php
+++ b/test/Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Success/function-with-parameter-without-type-declaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullableTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullableTypeDeclarationRule\Success;
 
 function foo($bar)
 {

--- a/test/Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Success/function-without-parameters.php
+++ b/test/Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Success/function-without-parameters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullableTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullableTypeDeclarationRule\Success;
 
 function foo(): void
 {

--- a/test/Fixture/Methods/FinalInAbstractClassRule/Failure/AbstractClassWithProtectedMethod.php
+++ b/test/Fixture/Methods/FinalInAbstractClassRule/Failure/AbstractClassWithProtectedMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Failure;
 
 abstract class AbstractClassWithProtectedMethod
 {

--- a/test/Fixture/Methods/FinalInAbstractClassRule/Failure/AbstractClassWithPublicMethod.php
+++ b/test/Fixture/Methods/FinalInAbstractClassRule/Failure/AbstractClassWithPublicMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Failure;
 
 abstract class AbstractClassWithPublicMethod
 {

--- a/test/Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithAbstractMethod.php
+++ b/test/Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithAbstractMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Success;
 
 abstract class AbstractClassWithAbstractMethod
 {

--- a/test/Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithFinalProtectedMethod.php
+++ b/test/Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithFinalProtectedMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Success;
 
 abstract class AbstractClassWithFinalProtectedMethod
 {

--- a/test/Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithFinalPublicMethod.php
+++ b/test/Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithFinalPublicMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Success;
 
 abstract class AbstractClassWithFinalPublicMethod
 {

--- a/test/Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithPrivateMethod.php
+++ b/test/Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithPrivateMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Success;
 
 abstract class AbstractClassWithPrivateMethod
 {

--- a/test/Fixture/Methods/FinalInAbstractClassRule/Success/InterfaceWithPublicMethod.php
+++ b/test/Fixture/Methods/FinalInAbstractClassRule/Success/InterfaceWithPublicMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Success;
 
 interface InterfaceWithPublicMethod
 {

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Failure/ConstructorInClassWithParameterWithDefaultValue.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Failure/ConstructorInClassWithParameterWithDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Failure;
 
 final class ConstructorInClassWithParameterWithDefaultValue
 {

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Failure/ConstructorWithWrongCapitalizationInClassWithParameterWithDefaultValue.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Failure/ConstructorWithWrongCapitalizationInClassWithParameterWithDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Failure;
 
 final class ConstructorWithWrongCapitalizationInClassWithParameterWithDefaultValue
 {

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Failure/constructor-in-anonymous-class-with-parameter-with-default-value.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Failure/constructor-in-anonymous-class-with-parameter-with-default-value.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
 
 new class() {
     public function __construct($bar = 9000)

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Failure/constructor-with-wrong-capitalization-in-anonymous-class-with-parameter-with-default-value.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Failure/constructor-with-wrong-capitalization-in-anonymous-class-with-parameter-with-default-value.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
 
 new class() {
     public function __CoNsTrUcT($bar = 9000)

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInClassWithParameterWithoutDefaultValue.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInClassWithParameterWithoutDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
 
 final class ConstructorInClassWithParameterWithoutDefaultValue
 {

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInClassWithoutParameters.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInClassWithoutParameters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
 
 final class ConstructorInClassWithoutParameters
 {

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInTraitWithParameterWithDefaultValue.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInTraitWithParameterWithDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
 
 trait ConstructorInTraitWithParameterWithDefaultValue
 {

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInTraitWithParameterWithoutDefaultValue.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInTraitWithParameterWithoutDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
 
 trait ConstructorInTraitWithParameterWithoutDefaultValue
 {

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInTraitWithoutParameters.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInTraitWithoutParameters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
 
 trait ConstructorInTraitWithoutParameters
 {

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/MethodInClassWithParameterWithDefaultValue.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/MethodInClassWithParameterWithDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
 
 final class MethodInClassWithParameterWithDefaultValue
 {

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/MethodInTraitWithParameterWithDefaultValue.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/MethodInTraitWithParameterWithDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
 
 trait MethodInTraitWithParameterWithDefaultValue
 {

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/constructor-in-anonymous-class-with-parameter-without-default-value.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/constructor-in-anonymous-class-with-parameter-without-default-value.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
 
 new class() {
     public function __construct($bar)

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/constructor-in-anonymous-class-without-parameters.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/constructor-in-anonymous-class-without-parameters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
 
 new class() {
     public function __construct()

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/method-in-anonymous-class-with-parameter-with-default-value.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/method-in-anonymous-class-with-parameter-with-default-value.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
 
 new class() {
     public function foo($bar = null): void

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Failure/MethodInAnonymousClassWithNullableReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Failure/MethodInAnonymousClassWithNullableReturnTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Failure;
 
 final class MethodInAnonymousClassWithNullableReturnTypeDeclaration
 {

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Failure/MethodInClassWithNullableReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Failure/MethodInClassWithNullableReturnTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Failure;
 
 final class MethodInClassWithNullableReturnTypeDeclaration
 {

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Failure/MethodInInterfaceWithNullableReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Failure/MethodInInterfaceWithNullableReturnTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Failure;
 
 interface MethodInInterfaceWithNullableReturnTypeDeclaration
 {

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Success/MethodInAnonymousClassWithReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Success/MethodInAnonymousClassWithReturnTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Success;
 
 final class MethodInAnonymousClassWithReturnTypeDeclaration
 {

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Success/MethodInAnonymousClassWithoutReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Success/MethodInAnonymousClassWithoutReturnTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Success;
 
 final class MethodInAnonymousClassWithoutReturnTypeDeclaration
 {

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Success/MethodInClassWithReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Success/MethodInClassWithReturnTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Success;
 
 final class MethodInClassWithReturnTypeDeclaration
 {

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Success/MethodInClassWithoutReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Success/MethodInClassWithoutReturnTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Success;
 
 final class MethodInClassWithoutReturnTypeDeclaration
 {

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Success/MethodInInterfaceWithReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Success/MethodInInterfaceWithReturnTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Success;
 
 interface MethodInInterfaceWithReturnTypeDeclaration
 {

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Success/MethodInInterfaceWithoutReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Success/MethodInInterfaceWithoutReturnTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Success;
 
 interface MethodInInterfaceWithoutReturnTypeDeclaration
 {

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Success/MethodInTraitWithNullableReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Success/MethodInTraitWithNullableReturnTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Success;
 
 trait MethodInTraitWithNullableReturnTypeDeclaration
 {

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Success/MethodInTraitWithReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Success/MethodInTraitWithReturnTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Success;
 
 trait MethodInTraitWithReturnTypeDeclaration
 {

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Success/MethodInTraitWithoutReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclarationRule/Success/MethodInTraitWithoutReturnTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclarationRule\Success;
 
 trait MethodInTraitWithoutReturnTypeDeclaration
 {

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/ClassImplementingContainerInterface.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/ClassImplementingContainerInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
 
 use Psr\Container;
 

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/ClassImplementingContainerInterfaceWithMethodWithParameterWithSelfAsTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/ClassImplementingContainerInterfaceWithMethodWithParameterWithSelfAsTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
 
 use Psr\Container;
 

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/ClassWithMethodWithParameterWithClassImplementingContainerInterfaceAsTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/ClassWithMethodWithParameterWithClassImplementingContainerInterfaceAsTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
 
 final class ClassWithMethodWithParameterWithClassImplementingContainerInterfaceAsTypeDeclaration
 {

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/ClassWithMethodWithParameterWithContainerInterfaceAsTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/ClassWithMethodWithParameterWithContainerInterfaceAsTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
 
 use Psr\Container;
 

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/ClassWithMethodWithParameterWithInterfaceExtendingContainerInterfaceAsTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/ClassWithMethodWithParameterWithInterfaceExtendingContainerInterfaceAsTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
 
 final class ClassWithMethodWithParameterWithInterfaceExtendingContainerInterfaceAsTypeDeclaration
 {

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/ClassWithMethodWithParameterWithServiceLocatorInterfaceAsTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/ClassWithMethodWithParameterWithServiceLocatorInterfaceAsTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
 
 use Zend\ServiceManager;
 

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/InterfaceExtendingContainerInterface.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/InterfaceExtendingContainerInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
 
 use Psr\Container;
 

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/InterfaceWithMethodWithParameterWithContainerInterfaceAsTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/InterfaceWithMethodWithParameterWithContainerInterfaceAsTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
 
 use Psr\Container;
 

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/InterfaceWithMethodWithParameterWithServiceLocatorInterfaceAsTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/InterfaceWithMethodWithParameterWithServiceLocatorInterfaceAsTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
 
 use Zend\ServiceManager;
 

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/anonymous-class-with-method-with-parameter-with-class-implementing-container-interface-as-type-declaration.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/anonymous-class-with-method-with-parameter-with-class-implementing-container-interface-as-type-declaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
 
 /** @var ClassImplementingContainerInterface $container */
 new class($container) {

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/anonymous-class-with-method-with-parameter-with-container-interface-as-type-declaration.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/anonymous-class-with-method-with-parameter-with-container-interface-as-type-declaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
 
 use Psr\Container;
 

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/anonymous-class-with-method-with-parameter-with-interface-extending-container-interface-as-type-declaration.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/anonymous-class-with-method-with-parameter-with-interface-extending-container-interface-as-type-declaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
 
 /** @var InterfaceExtendingContainerInterface $container */
 new class($container) {

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/anonymous-class-with-method-with-parameter-with-service-locator-interface-as-type-declaration.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/anonymous-class-with-method-with-parameter-with-service-locator-interface-as-type-declaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
 
 use Zend\ServiceManager;
 

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Success/ClassWithMethodWithParameterWithOtherTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Success/ClassWithMethodWithParameterWithOtherTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Success;
 
 final class ClassWithMethodWithParameterWithOtherTypeDeclaration
 {

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Success/ClassWithMethodWithoutParameter.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Success/ClassWithMethodWithoutParameter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Success;
 
 final class ClassWithMethodWithoutParameter
 {

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Success/ContainerInterface.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Success/ContainerInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Success;
 
 interface ContainerInterface
 {

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Success/InterfaceWithMethodWithParameterWithOtherTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Success/InterfaceWithMethodWithParameterWithOtherTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Success;
 
 interface InterfaceWithMethodWithParameterWithOtherTypeDeclaration
 {

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Success/InterfaceWithMethodWithoutParameter.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Success/InterfaceWithMethodWithoutParameter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Success;
 
 interface InterfaceWithMethodWithoutParameter
 {

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Success/anonymous-class-with-method-with-parameter-with-other-type-declaration.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Success/anonymous-class-with-method-with-parameter-with-other-type-declaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Success;
 
 new class() {
     public function __construct(ContainerInterface $container)

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Success/anonymous-class-with-method-without-parameter.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Success/anonymous-class-with-method-without-parameter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Success;
 
 new class() {
     public function __construct()

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInClassWithParameterWithNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInClassWithParameterWithNullDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure;
 
 final class MethodInClassWithParameterWithNullDefaultValue
 {

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInClassWithParameterWithRootNamespaceReferencedNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInClassWithParameterWithRootNamespaceReferencedNullDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure;
 
 final class MethodInClassWithParameterWithRootNamespaceReferencedNullDefaultValue
 {

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInClassWithParameterWithWronglyCapitalizedNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInClassWithParameterWithWronglyCapitalizedNullDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure;
 
 final class MethodInClassWithParameterWithWronglyCapitalizedNullDefaultValue
 {

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInInterfaceWithParameterWithNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInInterfaceWithParameterWithNullDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure;
 
 interface MethodInInterfaceWithParameterWithNullDefaultValue
 {

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInInterfaceWithParameterWithRootNamespaceReferencedNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInInterfaceWithParameterWithRootNamespaceReferencedNullDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure;
 
 interface MethodInInterfaceWithParameterWithRootNamespaceReferencedNullDefaultValue
 {

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInInterfaceWithParameterWithWronlgyCapitalizedNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInInterfaceWithParameterWithWronlgyCapitalizedNullDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure;
 
 interface MethodInInterfaceWithParameterWithWronlgyCapitalizedNullDefaultValue
 {

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/method-in-anonymous-class-with-parameter-with-null-default-value.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/method-in-anonymous-class-with-parameter-with-null-default-value.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
 
 new class() {
     public function foo($bar = null)

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/method-in-anonymous-class-with-parameter-with-root-namespace-referenced-null-default-value.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/method-in-anonymous-class-with-parameter-with-root-namespace-referenced-null-default-value.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
 
 new class() {
     public function foo($bar = \null)

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/method-in-anonymous-class-with-parameter-with-wrongly-capitalized-null-default-value.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/method-in-anonymous-class-with-parameter-with-wrongly-capitalized-null-default-value.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
 
 new class() {
     public function foo($bar = NuLl)

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInClassWithParameterWithNonNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInClassWithParameterWithNonNullDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
 
 final class MethodInClassWithParameterWithNonNullDefaultValue
 {

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInClassWithParameterWithoutDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInClassWithParameterWithoutDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
 
 final class MethodInClassWithParameterWithoutDefaultValue
 {

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInClassWithoutParameters.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInClassWithoutParameters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
 
 final class MethodInClassWithoutParameters
 {

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInInterfaceWithParameterWithNonNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInInterfaceWithParameterWithNonNullDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
 
 interface MethodInInterfaceWithParameterWithNonNullDefaultValue
 {

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInInterfaceWithParameterWithoutDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInInterfaceWithParameterWithoutDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
 
 interface MethodInInterfaceWithParameterWithoutDefaultValue
 {

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInInterfaceWithoutParameters.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInInterfaceWithoutParameters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
 
 interface MethodInInterfaceWithoutParameters
 {

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
 
 trait MethodInTraitWithParameterWithDefaultValue
 {

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithNonNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithNonNullDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
 
 trait MethodInTraitWithParameterWithNonNullDefaultValue
 {

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithRootNamespaceReferencedNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithRootNamespaceReferencedNullDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
 
 trait MethodInTraitWithParameterWithRootNamespaceReferencedNullDefaultValue
 {

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithWronlgyCapitalizedNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithWronlgyCapitalizedNullDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
 
 trait MethodInTraitWithParameterWithWronlgyCapitalizedNullDefaultValue
 {

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithoutDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithoutDefaultValue.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
 
 trait MethodInTraitWithParameterWithoutDefaultValue
 {

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithoutParameters.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithoutParameters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
 
 trait MethodInTraitWithoutParameters
 {

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/method-in-anonymous-class-with-parameter-with-non-null-default-value.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/method-in-anonymous-class-with-parameter-with-non-null-default-value.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
 
 new class() {
     public function foo($bar = true)

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/method-in-anonymous-class-with-parameter-without-default-value.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/method-in-anonymous-class-with-parameter-without-default-value.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
 
 new class() {
     public function foo($bar)

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/method-in-anonymous-class-without-parameters.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/method-in-anonymous-class-without-parameters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
 
 new class() {
     public function foo(): void

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Failure/MethodInClassWithParameterWithNullableTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Failure/MethodInClassWithParameterWithNullableTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Failure;
 
 final class MethodInClassWithParameterWithNullableTypeDeclaration
 {

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Failure/MethodInInterfaceWithParameterWithNullableTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Failure/MethodInInterfaceWithParameterWithNullableTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Failure;
 
 interface MethodInInterfaceWithParameterWithNullableTypeDeclaration
 {

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Failure/method-in-anonymous-class-with-parameter-with-nullable-type-declaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Failure/method-in-anonymous-class-with-parameter-with-nullable-type-declaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
 
 new class() {
     public function foo(?string $bar)

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInClassWithParameterWithTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInClassWithParameterWithTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
 
 final class MethodInClassWithParameterWithTypeDeclaration
 {

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInClassWithParameterWithoutTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInClassWithParameterWithoutTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
 
 final class MethodInClassWithParameterWithoutTypeDeclaration
 {

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInClassWithoutParameters.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInClassWithoutParameters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
 
 final class MethodInClassWithoutParameters
 {

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInInterfaceWithParameterWithTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInInterfaceWithParameterWithTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
 
 interface MethodInInterfaceWithParameterWithTypeDeclaration
 {

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInInterfaceWithParameterWithoutTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInInterfaceWithParameterWithoutTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
 
 interface MethodInInterfaceWithParameterWithoutTypeDeclaration
 {

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInInterfaceWithoutParameters.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInInterfaceWithoutParameters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
 
 interface MethodInInterfaceWithoutParameters
 {

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInTraitWithParameterWithNullableTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInTraitWithParameterWithNullableTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
 
 trait MethodInTraitWithParameterWithNullableTypeDeclaration
 {

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInTraitWithParameterWithTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInTraitWithParameterWithTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
 
 trait MethodInTraitWithParameterWithTypeDeclaration
 {

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInTraitWithParameterWithoutTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInTraitWithParameterWithoutTypeDeclaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
 
 trait MethodInTraitWithParameterWithoutTypeDeclaration
 {

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInTraitWithoutParameters.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInTraitWithoutParameters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
 
 trait MethodInTraitWithoutParameters
 {

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/method-in-anonymous-class-with-parameter-with-type-declaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/method-in-anonymous-class-with-parameter-with-type-declaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
 
 new class() {
     public function foo(string $bar)

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/method-in-anonymous-class-with-parameter-without-type-declaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/method-in-anonymous-class-with-parameter-without-type-declaration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
 
 new class() {
     public function foo($bar)

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/method-in-anonymous-class-without-parameters.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/method-in-anonymous-class-without-parameters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
 
 new class() {
     public function foo(): void

--- a/test/Fixture/Methods/PrivateInFinalClassRule/Failure/AnonymousClassWithProtectedMethod.php
+++ b/test/Fixture/Methods/PrivateInFinalClassRule/Failure/AnonymousClassWithProtectedMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Failure;
 
 new class() {
     protected function method(): void

--- a/test/Fixture/Methods/PrivateInFinalClassRule/Failure/FinalClassWithProtectedMethod.php
+++ b/test/Fixture/Methods/PrivateInFinalClassRule/Failure/FinalClassWithProtectedMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Failure;
 
 final class FinalClassWithProtectedMethod
 {

--- a/test/Fixture/Methods/PrivateInFinalClassRule/Success/AbstractClassExtendingAbstractClassWithProtectedMethod.php
+++ b/test/Fixture/Methods/PrivateInFinalClassRule/Success/AbstractClassExtendingAbstractClassWithProtectedMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
 
 abstract class AbstractClassExtendingAbstractClassWithProtectedMethod extends AbstractClassWithProtectedMethod
 {

--- a/test/Fixture/Methods/PrivateInFinalClassRule/Success/AbstractClassWithProtectedMethod.php
+++ b/test/Fixture/Methods/PrivateInFinalClassRule/Success/AbstractClassWithProtectedMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
 
 abstract class AbstractClassWithProtectedMethod
 {

--- a/test/Fixture/Methods/PrivateInFinalClassRule/Success/ClassWithProtectedMethod.php
+++ b/test/Fixture/Methods/PrivateInFinalClassRule/Success/ClassWithProtectedMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
 
 class ClassWithProtectedMethod
 {

--- a/test/Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithPrivateMethod.php
+++ b/test/Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithPrivateMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
 
 final class FinalClassWithPrivateMethod
 {

--- a/test/Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithProtectedMethodExtendingClassExtendingClassWithSameProtectedMethod.php
+++ b/test/Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithProtectedMethodExtendingClassExtendingClassWithSameProtectedMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
 
 final class FinalClassWithProtectedMethodExtendingClassExtendingClassWithSameProtectedMethod extends AbstractClassExtendingAbstractClassWithProtectedMethod
 {

--- a/test/Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithProtectedMethodExtendingClassWithSameProtectedMethod.php
+++ b/test/Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithProtectedMethodExtendingClassWithSameProtectedMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
 
 final class FinalClassWithProtectedMethodExtendingClassWithSameProtectedMethod extends AbstractClassWithProtectedMethod
 {

--- a/test/Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithPublicMethod.php
+++ b/test/Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithPublicMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
 
 final class FinalClassWithPublicMethod
 {

--- a/test/Fixture/Statements/NoSwitchRule/Failure/switch-used-with-correct-case.php
+++ b/test/Fixture/Statements/NoSwitchRule/Failure/switch-used-with-correct-case.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoSwitchRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Expressions\NoSwitchRule\Failure;
 
 switch ($foo) {
     case 'foo':

--- a/test/Fixture/Statements/NoSwitchRule/Failure/switch-used-with-incorrect-case.php
+++ b/test/Fixture/Statements/NoSwitchRule/Failure/switch-used-with-incorrect-case.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoSwitchRule\Failure;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Expressions\NoSwitchRule\Failure;
 
 sWiTcH ($foo) {
     case 'foo':

--- a/test/Fixture/Statements/NoSwitchRule/Success/switch-not-used.php
+++ b/test/Fixture/Statements/NoSwitchRule/Success/switch-not-used.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoSwitchRule\Success;
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Expressions\NoSwitchRule\Success;
 
 if ('foo' === $foo) {
     return 'It is foo!';

--- a/test/Integration/AbstractTestCase.php
+++ b/test/Integration/AbstractTestCase.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration;
+namespace Ergebnis\PHPStan\Rules\Test\Integration;
 
 use PHPStan\Testing\RuleTestCase;
 

--- a/test/Integration/Classes/FinalRuleTest.php
+++ b/test/Integration/Classes/FinalRuleTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Classes;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Classes;
 
-use Localheinz\PHPStan\Rules\Classes\FinalRule;
-use Localheinz\PHPStan\Rules\Test\Fixture;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Classes\FinalRule;
+use Ergebnis\PHPStan\Rules\Test\Fixture;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Classes\FinalRule
+ * @covers \Ergebnis\PHPStan\Rules\Classes\FinalRule
  */
 final class FinalRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Classes/FinalRuleWithAbstractClassesAllowedTest.php
+++ b/test/Integration/Classes/FinalRuleWithAbstractClassesAllowedTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Classes;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Classes;
 
-use Localheinz\PHPStan\Rules\Classes\FinalRule;
-use Localheinz\PHPStan\Rules\Test\Fixture;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Classes\FinalRule;
+use Ergebnis\PHPStan\Rules\Test\Fixture;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Classes\FinalRule
+ * @covers \Ergebnis\PHPStan\Rules\Classes\FinalRule
  */
 final class FinalRuleWithAbstractClassesAllowedTest extends AbstractTestCase
 {

--- a/test/Integration/Classes/FinalRuleWithExcludedClassNamesTest.php
+++ b/test/Integration/Classes/FinalRuleWithExcludedClassNamesTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Classes;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Classes;
 
-use Localheinz\PHPStan\Rules\Classes\FinalRule;
-use Localheinz\PHPStan\Rules\Test\Fixture;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Classes\FinalRule;
+use Ergebnis\PHPStan\Rules\Test\Fixture;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Classes\FinalRule
+ * @covers \Ergebnis\PHPStan\Rules\Classes\FinalRule
  */
 final class FinalRuleWithExcludedClassNamesTest extends AbstractTestCase
 {

--- a/test/Integration/Classes/NoExtendsRuleTest.php
+++ b/test/Integration/Classes/NoExtendsRuleTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Classes;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Classes;
 
-use Localheinz\PHPStan\Rules\Classes\NoExtendsRule;
-use Localheinz\PHPStan\Rules\Test\Fixture;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Classes\NoExtendsRule;
+use Ergebnis\PHPStan\Rules\Test\Fixture;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Classes\NoExtendsRule
+ * @covers \Ergebnis\PHPStan\Rules\Classes\NoExtendsRule
  */
 final class NoExtendsRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Classes/NoExtendsRuleWithClassesAllowedToBeExtendedTest.php
+++ b/test/Integration/Classes/NoExtendsRuleWithClassesAllowedToBeExtendedTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Classes;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Classes;
 
-use Localheinz\PHPStan\Rules\Classes\NoExtendsRule;
-use Localheinz\PHPStan\Rules\Test\Fixture;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Classes\NoExtendsRule;
+use Ergebnis\PHPStan\Rules\Test\Fixture;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Classes\NoExtendsRule
+ * @covers \Ergebnis\PHPStan\Rules\Classes\NoExtendsRule
  */
 final class NoExtendsRuleWithClassesAllowedToBeExtendedTest extends AbstractTestCase
 {

--- a/test/Integration/Closures/NoNullableReturnTypeDeclarationRuleTest.php
+++ b/test/Integration/Closures/NoNullableReturnTypeDeclarationRuleTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Closures;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Closures;
 
-use Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule
+ * @covers \Ergebnis\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule
  */
 final class NoNullableReturnTypeDeclarationRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Closures/NoParameterWithNullDefaultValueRuleTest.php
+++ b/test/Integration/Closures/NoParameterWithNullDefaultValueRuleTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Closures;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Closures;
 
-use Localheinz\PHPStan\Rules\Closures\NoParameterWithNullDefaultValueRule;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Closures\NoParameterWithNullDefaultValueRule;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Closures\NoParameterWithNullDefaultValueRule
+ * @covers \Ergebnis\PHPStan\Rules\Closures\NoParameterWithNullDefaultValueRule
  */
 final class NoParameterWithNullDefaultValueRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Closures/NoParameterWithNullableTypeDeclarationRuleTest.php
+++ b/test/Integration/Closures/NoParameterWithNullableTypeDeclarationRuleTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Closures;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Closures;
 
-use Localheinz\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule
+ * @covers \Ergebnis\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule
  */
 final class NoParameterWithNullableTypeDeclarationRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Expressions/NoCompactRuleTest.php
+++ b/test/Integration/Expressions/NoCompactRuleTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Expressions;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Expressions;
 
-use Localheinz\PHPStan\Rules\Expressions\NoCompactRule;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Expressions\NoCompactRule;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Expressions\NoCompactRule
+ * @covers \Ergebnis\PHPStan\Rules\Expressions\NoCompactRule
  */
 final class NoCompactRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Expressions/NoEmptyRuleTest.php
+++ b/test/Integration/Expressions/NoEmptyRuleTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Expressions;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Expressions;
 
-use Localheinz\PHPStan\Rules\Expressions\NoEmptyRule;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Expressions\NoEmptyRule;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Expressions\NoEmptyRule
+ * @covers \Ergebnis\PHPStan\Rules\Expressions\NoEmptyRule
  */
 final class NoEmptyRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Expressions/NoErrorSuppressionRuleTest.php
+++ b/test/Integration/Expressions/NoErrorSuppressionRuleTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Expressions;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Expressions;
 
-use Localheinz\PHPStan\Rules\Expressions\NoErrorSuppressionRule;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Expressions\NoErrorSuppressionRule;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Expressions\NoErrorSuppressionRule
+ * @covers \Ergebnis\PHPStan\Rules\Expressions\NoErrorSuppressionRule
  */
 final class NoErrorSuppressionRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Expressions/NoEvalRuleTest.php
+++ b/test/Integration/Expressions/NoEvalRuleTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Expressions;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Expressions;
 
-use Localheinz\PHPStan\Rules\Expressions\NoEvalRule;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Expressions\NoEvalRule;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Expressions\NoEvalRule
+ * @covers \Ergebnis\PHPStan\Rules\Expressions\NoEvalRule
  */
 final class NoEvalRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Expressions/NoIssetRuleTest.php
+++ b/test/Integration/Expressions/NoIssetRuleTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Expressions;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Expressions;
 
-use Localheinz\PHPStan\Rules\Expressions\NoIssetRule;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Expressions\NoIssetRule;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Expressions\NoIssetRule
+ * @covers \Ergebnis\PHPStan\Rules\Expressions\NoIssetRule
  */
 final class NoIssetRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Files/DeclareStrictTypesRuleTest.php
+++ b/test/Integration/Files/DeclareStrictTypesRuleTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Files;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Files;
 
-use Localheinz\PHPStan\Rules\Files\DeclareStrictTypesRule;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Files\DeclareStrictTypesRule;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Files\DeclareStrictTypesRule
+ * @covers \Ergebnis\PHPStan\Rules\Files\DeclareStrictTypesRule
  */
 final class DeclareStrictTypesRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Functions/NoNullableReturnTypeDeclarationRuleTest.php
+++ b/test/Integration/Functions/NoNullableReturnTypeDeclarationRuleTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Functions;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Functions;
 
-use Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule
+ * @covers \Ergebnis\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule
  */
 final class NoNullableReturnTypeDeclarationRuleTest extends AbstractTestCase
 {
@@ -44,7 +44,7 @@ final class NoNullableReturnTypeDeclarationRuleTest extends AbstractTestCase
             'function-with-nullable-return-type-declaration' => [
                 __DIR__ . '/../../Fixture/Functions/NoNullableReturnTypeDeclarationRule/Failure/function-with-nullable-return-type-declaration.php',
                 [
-                    'Function Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullableReturnTypeDeclarationRule\Failure\foo() has a nullable return type declaration.',
+                    'Function Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoNullableReturnTypeDeclarationRule\Failure\foo() has a nullable return type declaration.',
                     7,
                 ],
             ],

--- a/test/Integration/Functions/NoParameterWithNullDefaultValueRuleTest.php
+++ b/test/Integration/Functions/NoParameterWithNullDefaultValueRuleTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Functions;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Functions;
 
-use Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule
+ * @covers \Ergebnis\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule
  */
 final class NoParameterWithNullDefaultValueRuleTest extends AbstractTestCase
 {
@@ -45,21 +45,21 @@ final class NoParameterWithNullDefaultValueRuleTest extends AbstractTestCase
             'function-with-parameter-with-null-default-value' => [
                 __DIR__ . '/../../Fixture/Functions/NoParameterWithNullDefaultValueRule/Failure/function-with-parameter-with-null-default-value.php',
                 [
-                    'Function Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Failure\foo() has parameter $bar with null as default value.',
+                    'Function Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Failure\foo() has parameter $bar with null as default value.',
                     7,
                 ],
             ],
             'function-with-parameter-with-root-namespace-referenced-null-default-value' => [
                 __DIR__ . '/../../Fixture/Functions/NoParameterWithNullDefaultValueRule/Failure/function-with-parameter-with-root-namespace-referenced-null-default-value.php',
                 [
-                    'Function Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Failure\foo() has parameter $bar with null as default value.',
+                    'Function Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Failure\foo() has parameter $bar with null as default value.',
                     7,
                 ],
             ],
             'function-with-parameter-with-wrongly-capitalized-null-default-value' => [
                 __DIR__ . '/../../Fixture/Functions/NoParameterWithNullDefaultValueRule/Failure/function-with-parameter-with-wrongly-capitalized-null-default-value.php',
                 [
-                    'Function Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Failure\foo() has parameter $bar with null as default value.',
+                    'Function Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Failure\foo() has parameter $bar with null as default value.',
                     7,
                 ],
             ],

--- a/test/Integration/Functions/NoParameterWithNullableTypeDeclarationRuleTest.php
+++ b/test/Integration/Functions/NoParameterWithNullableTypeDeclarationRuleTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Functions;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Functions;
 
-use Localheinz\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclarationRule;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclarationRule;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclarationRule
+ * @covers \Ergebnis\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclarationRule
  */
 final class NoParameterWithNullableTypeDeclarationRuleTest extends AbstractTestCase
 {
@@ -45,7 +45,7 @@ final class NoParameterWithNullableTypeDeclarationRuleTest extends AbstractTestC
             'function-with-parameter-with-nullable-type-declaration' => [
                 __DIR__ . '/../../Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Failure/function-with-parameter-with-nullable-type-declaration.php',
                 [
-                    'Function Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullableTypeDeclarationRule\Failure\foo() has parameter $bar with a nullable type declaration.',
+                    'Function Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullableTypeDeclarationRule\Failure\foo() has parameter $bar with a nullable type declaration.',
                     7,
                 ],
             ],

--- a/test/Integration/Methods/FinalInAbstractClassRuleTest.php
+++ b/test/Integration/Methods/FinalInAbstractClassRuleTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Methods;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Methods;
 
-use Localheinz\PHPStan\Rules\Methods\FinalInAbstractClassRule;
-use Localheinz\PHPStan\Rules\Test\Fixture;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Methods\FinalInAbstractClassRule;
+use Ergebnis\PHPStan\Rules\Test\Fixture;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Methods\FinalInAbstractClassRule
+ * @covers \Ergebnis\PHPStan\Rules\Methods\FinalInAbstractClassRule
  */
 final class FinalInAbstractClassRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Methods/NoConstructorParameterWithDefaultValueRuleTest.php
+++ b/test/Integration/Methods/NoConstructorParameterWithDefaultValueRuleTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Methods;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Methods;
 
-use Localheinz\PHPStan\Rules\Methods\NoConstructorParameterWithDefaultValueRule;
-use Localheinz\PHPStan\Rules\Test\Fixture;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Methods\NoConstructorParameterWithDefaultValueRule;
+use Ergebnis\PHPStan\Rules\Test\Fixture;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Methods\NoConstructorParameterWithDefaultValueRule
+ * @covers \Ergebnis\PHPStan\Rules\Methods\NoConstructorParameterWithDefaultValueRule
  */
 final class NoConstructorParameterWithDefaultValueRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Methods/NoNullableReturnTypeDeclarationRuleTest.php
+++ b/test/Integration/Methods/NoNullableReturnTypeDeclarationRuleTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Methods;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Methods;
 
-use Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule;
-use Localheinz\PHPStan\Rules\Test\Fixture;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule;
+use Ergebnis\PHPStan\Rules\Test\Fixture;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule
+ * @covers \Ergebnis\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule
  */
 final class NoNullableReturnTypeDeclarationRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Methods/NoParameterWithContainerTypeDeclarationRuleTest.php
+++ b/test/Integration/Methods/NoParameterWithContainerTypeDeclarationRuleTest.php
@@ -8,14 +8,14 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Methods;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Methods;
 
-use Localheinz\PHPStan\Rules\Methods\NoParameterWithContainerTypeDeclarationRule;
-use Localheinz\PHPStan\Rules\Test\Fixture;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Methods\NoParameterWithContainerTypeDeclarationRule;
+use Ergebnis\PHPStan\Rules\Test\Fixture;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 use Psr\Container;
 use Zend\ServiceManager;
@@ -23,7 +23,7 @@ use Zend\ServiceManager;
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Methods\NoParameterWithContainerTypeDeclarationRule
+ * @covers \Ergebnis\PHPStan\Rules\Methods\NoParameterWithContainerTypeDeclarationRule
  */
 final class NoParameterWithContainerTypeDeclarationRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Methods/NoParameterWithNullDefaultValueRuleTest.php
+++ b/test/Integration/Methods/NoParameterWithNullDefaultValueRuleTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Methods;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Methods;
 
-use Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule;
-use Localheinz\PHPStan\Rules\Test\Fixture;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule;
+use Ergebnis\PHPStan\Rules\Test\Fixture;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule
+ * @covers \Ergebnis\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule
  */
 final class NoParameterWithNullDefaultValueRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Methods/NoParameterWithNullableTypeDeclarationRuleTest.php
+++ b/test/Integration/Methods/NoParameterWithNullableTypeDeclarationRuleTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Methods;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Methods;
 
-use Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule;
-use Localheinz\PHPStan\Rules\Test\Fixture;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule;
+use Ergebnis\PHPStan\Rules\Test\Fixture;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule
+ * @covers \Ergebnis\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule
  */
 final class NoParameterWithNullableTypeDeclarationRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Methods/PrivateInFinalClassRuleTest.php
+++ b/test/Integration/Methods/PrivateInFinalClassRuleTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Methods;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Methods;
 
-use Localheinz\PHPStan\Rules\Methods\PrivateInFinalClassRule;
-use Localheinz\PHPStan\Rules\Test\Fixture;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Methods\PrivateInFinalClassRule;
+use Ergebnis\PHPStan\Rules\Test\Fixture;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Methods\PrivateInFinalClassRule
+ * @covers \Ergebnis\PHPStan\Rules\Methods\PrivateInFinalClassRule
  */
 final class PrivateInFinalClassRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Statements/NoSwitchRuleTest.php
+++ b/test/Integration/Statements/NoSwitchRuleTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/phpstan-rules
+ * @see https://github.com/ergebnis/phpstan-rules
  */
 
-namespace Localheinz\PHPStan\Rules\Test\Integration\Statements;
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Statements;
 
-use Localheinz\PHPStan\Rules\Statements\NoSwitchRule;
-use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use Ergebnis\PHPStan\Rules\Statements\NoSwitchRule;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
 use PHPStan\Rules\Rule;
 
 /**
  * @internal
  *
- * @covers \Localheinz\PHPStan\Rules\Statements\NoSwitchRule
+ * @covers \Ergebnis\PHPStan\Rules\Statements\NoSwitchRule
  */
 final class NoSwitchRuleTest extends AbstractTestCase
 {


### PR DESCRIPTION
This PR

* [x] renames the vendor namespace `Localheinz` to `Ergebnis` after the move to @ergebnis