### PR TITLE
Fix: Remove inappropriate replace configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.14.0...master`][0.14.0...master].
+For a full diff see [`0.14.1...master`][0.14.1...master].
+
+## [`0.14.1`][0.14.1]
+
+For a full diff see [`0.14.0...0.14.1`][0.14.0...0.14.1].
+
+### Fixed
+
+* Removed an inappropriate `replace` configuration from `composer.json` ([#161]), by [@localheinz]
 
 ## [`0.14.0`][0.14.0]
 
@@ -278,6 +286,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [0.12.2]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.12.2
 [0.13.0]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.13.0
 [0.14.0]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.14.0
+[0.14.1]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.14.1
 
 [362c7ea...0.1.0]: https://github.com/ergebnis/phpstan-rules/compare/362c7ea...0.1.0
 [0.1.0...0.2.0]: https://github.com/ergebnis/phpstan-rules/compare/0.1.0...0.2.0
@@ -298,7 +307,8 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [0.12.1...0.12.2]: https://github.com/ergebnis/phpstan-rules/compare/0.12.1...0.12.2
 [0.12.2...0.13.0]: https://github.com/ergebnis/phpstan-rules/compare/0.12.2...0.13.0
 [0.13.0...0.14.0]: https://github.com/ergebnis/phpstan-rules/compare/0.13.0...0.14.0
-[0.14.0...master]: https://github.com/ergebnis/phpstan-rules/compare/0.14.0...master
+[0.14.0...0.14.1]: https://github.com/ergebnis/phpstan-rules/compare/0.14.0...0.14.1
+[0.14.1...master]: https://github.com/ergebnis/phpstan-rules/compare/0.14.1...master
 
 [#1]: https://github.com/ergebnis/phpstan-rules/pull/1
 [#4]: https://github.com/ergebnis/phpstan-rules/pull/4
@@ -343,6 +353,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [#147]: https://github.com/ergebnis/phpstan-rules/pull/147
 [#157]: https://github.com/ergebnis/phpstan-rules/pull/157
 [#158]: https://github.com/ergebnis/phpstan-rules/pull/158
+[#161]: https://github.com/ergebnis/phpstan-rules/pull/161
 
 [@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,6 @@
     "nikic/php-parser": "^4.2.3",
     "phpstan/phpstan": "~0.11.15 || ~0.12.0"
   },
-  "replace": {
-    "localheinz/phpstan-rules": "*"
-  },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.1.0",
     "ergebnis/test-util": "~0.9.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0177864a9adb8a2186532b971d015000",
+    "content-hash": "b57815341bc06d4afa92383b66959cb6",
     "packages": [
         {
             "name": "composer/xdebug-handler",


### PR DESCRIPTION
This PR

* [x] removes an inappropriate `replace` configuration from `composer.json`

Follows #157.