### PR TITLE
Fix: Ignore entities with ORM\Mapping\Entity annotations in FinalRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.14.3...master`][0.14.3...master].
+For a full diff see [`0.14.4...master`][0.14.4...master].
+
+## [`0.14.4`][0.14.4]
+
+For a full diff see [`0.14.3...0.14.4`][0.14.3...0.14.4].
+
+### Fixed
+
+* Ignored classes with `@ORM\Mapping\Entity` annotations in `FinalRule` ([#202]), by [@localheinz]
 
 ## [`0.14.3`][0.14.3]
 
@@ -305,6 +313,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [0.14.1]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.14.1
 [0.14.2]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.14.2
 [0.14.3]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.14.3
+[0.14.4]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.14.4
 
 [362c7ea...0.1.0]: https://github.com/ergebnis/phpstan-rules/compare/362c7ea...0.1.0
 [0.1.0...0.2.0]: https://github.com/ergebnis/phpstan-rules/compare/0.1.0...0.2.0
@@ -328,7 +337,8 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [0.14.0...0.14.1]: https://github.com/ergebnis/phpstan-rules/compare/0.14.0...0.14.1
 [0.14.1...0.14.2]: https://github.com/ergebnis/phpstan-rules/compare/0.14.1...0.14.2
 [0.14.2...0.14.3]: https://github.com/ergebnis/phpstan-rules/compare/0.14.2...0.14.3
-[0.14.3...master]: https://github.com/ergebnis/phpstan-rules/compare/0.14.3...master
+[0.14.3...0.14.4]: https://github.com/ergebnis/phpstan-rules/compare/0.14.3...0.14.4
+[0.14.4...master]: https://github.com/ergebnis/phpstan-rules/compare/0.14.4...master
 
 [#1]: https://github.com/ergebnis/phpstan-rules/pull/1
 [#4]: https://github.com/ergebnis/phpstan-rules/pull/4
@@ -376,6 +386,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [#161]: https://github.com/ergebnis/phpstan-rules/pull/161
 [#166]: https://github.com/ergebnis/phpstan-rules/pull/166
 [#186]: https://github.com/ergebnis/phpstan-rules/pull/186
+[#202]: https://github.com/ergebnis/phpstan-rules/pull/202
 
 [@ergebnis]: https://github.com/ergebnis
 [@Great-Antique]: https://github.com/Great-Antique

--- a/src/Classes/FinalRule.php
+++ b/src/Classes/FinalRule.php
@@ -27,6 +27,7 @@ final class FinalRule implements Rule
     private static $whitelistedAnnotations = [
         'Entity',
         'ORM\Entity',
+        'ORM\Mapping\Entity',
     ];
 
     /**

--- a/test/Fixture/Classes/FinalRule/Success/NonFinalClassWithOrmMappingEntityAnnotationInInlineDocBlock.php
+++ b/test/Fixture/Classes/FinalRule/Success/NonFinalClassWithOrmMappingEntityAnnotationInInlineDocBlock.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
+
+/** @ORM\Mapping\Entity */
+class NonFinalClassWithOrmMappingEntityAnnotationInInlineDocBlock
+{
+}

--- a/test/Fixture/Classes/FinalRule/Success/NonFinalClassWithOrmMappingEntityAnnotationInMultilineDocBlock.php
+++ b/test/Fixture/Classes/FinalRule/Success/NonFinalClassWithOrmMappingEntityAnnotationInMultilineDocBlock.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
+
+/**
+ * @ORM\Mapping\Table(name="hmm")
+ * @ORM\Mapping\Entity
+ */
+class NonFinalClassWithOrmMappingEntityAnnotationInMultilineDocBlock
+{
+}

--- a/test/Integration/Classes/FinalRuleTest.php
+++ b/test/Integration/Classes/FinalRuleTest.php
@@ -35,6 +35,8 @@ final class FinalRuleTest extends AbstractTestCase
             'non-final-class-with-entity-annotation-in-multi-line-doc-block' => __DIR__ . '/../../Fixture/Classes/FinalRule/Success/NonFinalClassWithEntityAnnotationInMultilineDocBlock.php',
             'non-final-class-with-orm-entity-annotation-in-inline-doc-block' => __DIR__ . '/../../Fixture/Classes/FinalRule/Success/NonFinalClassWithOrmEntityAnnotationInInlineDocBlock.php',
             'non-final-class-with-orm-entity-annotation-in-multi-line-doc-block' => __DIR__ . '/../../Fixture/Classes/FinalRule/Success/NonFinalClassWithOrmEntityAnnotationInMultilineDocBlock.php',
+            'non-final-class-with-orm-mapping-entity-annotation-in-inline-doc-block' => __DIR__ . '/../../Fixture/Classes/FinalRule/Success/NonFinalClassWithOrmMappingEntityAnnotationInInlineDocBlock.php',
+            'non-final-class-with-orm-mapping-entity-annotation-in-multi-line-doc-block' => __DIR__ . '/../../Fixture/Classes/FinalRule/Success/NonFinalClassWithOrmMappingEntityAnnotationInMultilineDocBlock.php',
             'script-with-anonymous-class' => __DIR__ . '/../../Fixture/Classes/FinalRule/Success/anonymous-class.php',
             'trait' => __DIR__ . '/../../Fixture/Classes/FinalRule/Success/ExampleTrait.php',
             'trait-with-anonymous-class' => __DIR__ . '/../../Fixture/Classes/FinalRule/Success/TraitWithAnonymousClass.php',


### PR DESCRIPTION
This PR

* [x] ignores entities with `@ORM\Mapping\Entity` annotations in `FinalRule`