### PR TITLE
Enhancement: Implement Classes\PHPUnit\Framework\TestCaseWithSuffixRule

### DIFF
--- a/.php_cs.fixture
+++ b/.php_cs.fixture
@@ -18,6 +18,7 @@ $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71(''), [
     'declare_strict_types' => false,
     'error_suppression' => false,
     'final_class' => false,
+    'final_internal_class' => false,
     'final_public_method_for_abstract_class' => false,
     'header_comment' => false,
     'lowercase_constants' => false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.14.4...master`][0.14.4...master].
+For a full diff see [`0.15.0...master`][0.15.0...master].
+
+## [`0.15.0`][0.15.0]
+
+For a full diff see [`0.14.4...0.15.0`][0.14.4...0.15.0].
+
+### Added
+
+* Added `Classes\PHPUnit\Framework\TestCaseWithSuffixRule`, which reports an error when a concrete class extending `PHPUnit\Framework\TestCase` does not have a `Test` suffix ([#225], by [@localheinz]
 
 ## [`0.14.4`][0.14.4]
 
@@ -314,6 +322,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [0.14.2]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.14.2
 [0.14.3]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.14.3
 [0.14.4]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.14.4
+[0.15.0]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.15.0
 
 [362c7ea...0.1.0]: https://github.com/ergebnis/phpstan-rules/compare/362c7ea...0.1.0
 [0.1.0...0.2.0]: https://github.com/ergebnis/phpstan-rules/compare/0.1.0...0.2.0
@@ -338,7 +347,8 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [0.14.1...0.14.2]: https://github.com/ergebnis/phpstan-rules/compare/0.14.1...0.14.2
 [0.14.2...0.14.3]: https://github.com/ergebnis/phpstan-rules/compare/0.14.2...0.14.3
 [0.14.3...0.14.4]: https://github.com/ergebnis/phpstan-rules/compare/0.14.3...0.14.4
-[0.14.4...master]: https://github.com/ergebnis/phpstan-rules/compare/0.14.4...master
+[0.14.4...0.15.0]: https://github.com/ergebnis/phpstan-rules/compare/0.14.4...0.15.0
+[0.15.0...master]: https://github.com/ergebnis/phpstan-rules/compare/0.15.0...master
 
 [#1]: https://github.com/ergebnis/phpstan-rules/pull/1
 [#4]: https://github.com/ergebnis/phpstan-rules/pull/4
@@ -387,6 +397,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [#166]: https://github.com/ergebnis/phpstan-rules/pull/166
 [#186]: https://github.com/ergebnis/phpstan-rules/pull/186
 [#202]: https://github.com/ergebnis/phpstan-rules/pull/202
+[#225]: https://github.com/ergebnis/phpstan-rules/pull/225
 
 [@ergebnis]: https://github.com/ergebnis
 [@Great-Antique]: https://github.com/Great-Antique

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 
 * [`Ergebnis\PHPStan\Rules\Classes\FinalRule`](https://github.com/ergebnis/phpstan-rules#classesfinalrule)
 * [`Ergebnis\PHPStan\Rules\Classes\NoExtendsRule`](https://github.com/ergebnis/phpstan-rules#classesnoextendsrule)
+* [`Ergebnis\PHPStan\Rules\Classes\PHPUnit\Framework\TestCaseWithSuffixRule`](https://github.com/ergebnis/phpstan-rules#classesphpunitframeworktestcasewithsuffixrule)
 * [`Ergebnis\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule`](https://github.com/ergebnis/phpstan-rules#closuresnonullablereturntypedeclarationrule)
 * [`Ergebnis\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule`](https://github.com/ergebnis/phpstan-rules#closuresnoparameterwithnullabletypedeclarationrule)
 * [`Ergebnis\PHPStan\Rules\Closures\NoParameterWithNullDefaultValueRule`](https://github.com/ergebnis/phpstan-rules#closuresnoparameterwithnulldefaultvaluerule)
@@ -118,6 +119,9 @@ parameters:
 			- Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase
 			- PHPStan\Testing\RuleTestCase
 ```
+#### `Classes\PHPUnit\Framework\TestCaseWithSuffixRule`
+
+This rule reports an error when a concrete class is a sub-class of `PHPUnit\Framework\TestCase` but does not have a `Test` suffix.
 
 ### Closures
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25,6 +25,11 @@ parameters:
 		-
 			message: "#^Language construct isset\\(\\) should not be used\\.$#"
 			count: 1
+			path: src/Classes/PHPUnit/Framework/TestCaseWithSuffixRule.php
+
+		-
+			message: "#^Language construct isset\\(\\) should not be used\\.$#"
+			count: 1
 			path: src/Functions/NoNullableReturnTypeDeclarationRule.php
 
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.10.1@eeed5ecccc10131397f0eb7ee6da810c0be3a7fc">
+<files psalm-version="3.11.2@d470903722cfcbc1cd04744c5491d3e6d13ec3d9">
   <file src="src/Classes/FinalRule.php">
     <MixedArgument occurrences="3">
       <code>$node-&gt;namespacedName</code>
@@ -19,6 +19,15 @@
       <code>$node-&gt;namespacedName</code>
     </MixedArgument>
     <PropertyTypeCoercion occurrences="1"/>
+  </file>
+  <file src="src/Classes/PHPUnit/Framework/TestCaseWithSuffixRule.php">
+    <MixedArgument occurrences="2">
+      <code>$node-&gt;namespacedName-&gt;toString()</code>
+      <code>$node-&gt;namespacedName</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="1">
+      <code>toString</code>
+    </MixedMethodCall>
   </file>
   <file src="src/Functions/NoNullableReturnTypeDeclarationRule.php">
     <MixedArgument occurrences="1">

--- a/rules.neon
+++ b/rules.neon
@@ -42,10 +42,16 @@ services:
 			classesNotRequiredToBeAbstractOrFinal: %ergebnis.classesNotRequiredToBeAbstractOrFinal%
 		tags:
 			- phpstan.rules.rule
+
 	-
 		class: Ergebnis\PHPStan\Rules\Classes\NoExtendsRule
 		arguments:
 			classesAllowedToBeExtended: %ergebnis.classesAllowedToBeExtended%
+		tags:
+			- phpstan.rules.rule
+
+	-
+		class: Ergebnis\PHPStan\Rules\Classes\PHPUnit\Framework\TestCaseWithSuffixRule
 		tags:
 			- phpstan.rules.rule
 

--- a/src/Classes/PHPUnit/Framework/TestCaseWithSuffixRule.php
+++ b/src/Classes/PHPUnit/Framework/TestCaseWithSuffixRule.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpstan-rules
+ */
+
+namespace Ergebnis\PHPStan\Rules\Classes\PHPUnit\Framework;
+
+use PhpParser\Node;
+use PHPStan\Analyser;
+use PHPStan\Broker;
+use PHPStan\Rules;
+use PHPStan\ShouldNotHappenException;
+
+final class TestCaseWithSuffixRule implements Rules\Rule
+{
+    /**
+     * @var string[]
+     */
+    private static $phpunitTestCaseClassNames = [
+        'PHPUnit\Framework\TestCase',
+    ];
+
+    /**
+     * @var Broker\Broker
+     */
+    private $broker;
+
+    public function __construct(Broker\Broker $broker)
+    {
+        $this->broker = $broker;
+    }
+
+    public function getNodeType(): string
+    {
+        return Node\Stmt\Class_::class;
+    }
+
+    public function processNode(Node $node, Analyser\Scope $scope): array
+    {
+        if (!$node instanceof Node\Stmt\Class_) {
+            throw new ShouldNotHappenException(\sprintf(
+                'Expected node to be instance of "%s", but got instance of "%s" instead.',
+                Node\Stmt\Class_::class,
+                \get_class($node)
+            ));
+        }
+
+        if ($node->isAbstract()) {
+            return [];
+        }
+
+        if (!$node->extends instanceof Node\Name) {
+            return [];
+        }
+
+        if (!isset($node->namespacedName)) {
+            return [];
+        }
+
+        /** @var string $fullyQualifiedClassName */
+        $fullyQualifiedClassName = $node->namespacedName->toString();
+
+        $classReflection = $this->broker->getClass($fullyQualifiedClassName);
+
+        $extendedPhpunitTestCaseClassName = '';
+
+        foreach (self::$phpunitTestCaseClassNames as $phpunitTestCaseClassName) {
+            if ($classReflection->isSubclassOf($phpunitTestCaseClassName)) {
+                $extendedPhpunitTestCaseClassName = $phpunitTestCaseClassName;
+
+                break;
+            }
+        }
+
+        if ('' === $extendedPhpunitTestCaseClassName) {
+            return [];
+        }
+
+        if (1 === \preg_match('/Test$/', $fullyQualifiedClassName)) {
+            return [];
+        }
+
+        return [
+            \sprintf(
+                'Class %s extends %s, is concrete, but does not have a Test suffix.',
+                $fullyQualifiedClassName,
+                $extendedPhpunitTestCaseClassName
+            ),
+        ];
+    }
+}

--- a/test/Fixture/Classes/PHPUnit/Framework/TestCaseWithSuffixRule/Failure/AbstractTestCase.php
+++ b/test/Fixture/Classes/PHPUnit/Framework/TestCaseWithSuffixRule/Failure/AbstractTestCase.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\PHPUnit\Framework\TestCaseWithSuffixRule\Failure;
+
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ */
+abstract class AbstractTestCase extends Framework\TestCase
+{
+}

--- a/test/Fixture/Classes/PHPUnit/Framework/TestCaseWithSuffixRule/Failure/ConcreteTestCaseExtendingAbstractTestCaseWithoutTestSuffix.php
+++ b/test/Fixture/Classes/PHPUnit/Framework/TestCaseWithSuffixRule/Failure/ConcreteTestCaseExtendingAbstractTestCaseWithoutTestSuffix.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\PHPUnit\Framework\TestCaseWithSuffixRule\Failure;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+final class ConcreteTestCaseExtendingAbstractTestCaseWithoutTestSuffix extends AbstractTestCase
+{
+}

--- a/test/Fixture/Classes/PHPUnit/Framework/TestCaseWithSuffixRule/Failure/ConcreteTestCaseWithoutTestSuffix.php
+++ b/test/Fixture/Classes/PHPUnit/Framework/TestCaseWithSuffixRule/Failure/ConcreteTestCaseWithoutTestSuffix.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\PHPUnit\Framework\TestCaseWithSuffixRule\Failure;
+
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+final class ConcreteTestCaseWithoutTestSuffix extends Framework\TestCase
+{
+    public function testFooIsNotBar(): void
+    {
+        self::assertNotSame('bar', 'foo');
+    }
+}

--- a/test/Fixture/Classes/PHPUnit/Framework/TestCaseWithSuffixRule/Success/ConcreteTestCaseWithSuffixTest.php
+++ b/test/Fixture/Classes/PHPUnit/Framework/TestCaseWithSuffixRule/Success/ConcreteTestCaseWithSuffixTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\PHPUnit\Framework\TestCaseWithSuffixRule\Success;
+
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+final class ConcreteTestCaseWithSuffixTest extends Framework\TestCase
+{
+    public function testFooIsNotBar(): void
+    {
+        self::assertNotSame('bar', 'foo');
+    }
+}

--- a/test/Fixture/Classes/PHPUnit/Framework/TestCaseWithSuffixRule/Success/ExplicitlyAbstractTestCase.php
+++ b/test/Fixture/Classes/PHPUnit/Framework/TestCaseWithSuffixRule/Success/ExplicitlyAbstractTestCase.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\PHPUnit\Framework\TestCaseWithSuffixRule\Success;
+
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ */
+abstract class ExplicitlyAbstractTestCase extends Framework\TestCase
+{
+}

--- a/test/Fixture/Classes/PHPUnit/Framework/TestCaseWithSuffixRule/Success/ImplicitlyAbstractTestCase.php
+++ b/test/Fixture/Classes/PHPUnit/Framework/TestCaseWithSuffixRule/Success/ImplicitlyAbstractTestCase.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Classes\PHPUnit\Framework\TestCaseWithSuffixRule\Success;
+
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+class ImplicitlyAbstractTestCase extends Framework\TestCase
+{
+    abstract protected function foo();
+}

--- a/test/Integration/Classes/PHPUnit/Framework/TestCaseWithSuffixRuleTest.php
+++ b/test/Integration/Classes/PHPUnit/Framework/TestCaseWithSuffixRuleTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpstan-rules
+ */
+
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Classes\PHPUnit\Framework;
+
+use Ergebnis\PHPStan\Rules\Classes\PHPUnit\Framework\TestCaseWithSuffixRule;
+use Ergebnis\PHPStan\Rules\Test\Fixture;
+use Ergebnis\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use PHPStan\Rules\Rule;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @covers \Ergebnis\PHPStan\Rules\Classes\PHPUnit\Framework\TestCaseWithSuffixRule
+ */
+final class TestCaseWithSuffixRuleTest extends AbstractTestCase
+{
+    public function provideCasesWhereAnalysisShouldSucceed(): iterable
+    {
+        $paths = [
+            'concrete-test-case-with-suffix-test' => __DIR__ . '/../../../../Fixture/Classes/PHPUnit/Framework/TestCaseWithSuffixRule/Success/ConcreteTestCaseWithSuffixTest.php',
+            'explicitly-abstract-test-case' => __DIR__ . '/../../../../Fixture/Classes/PHPUnit/Framework/TestCaseWithSuffixRule/Success/ExplicitlyAbstractTestCase.php',
+            'implicitly-abstract-test-case' => __DIR__ . '/../../../../Fixture/Classes/PHPUnit/Framework/TestCaseWithSuffixRule/Success/ExplicitlyAbstractTestCase.php',
+        ];
+
+        foreach ($paths as $description => $path) {
+            yield $description => [
+                $path,
+            ];
+        }
+    }
+
+    public function provideCasesWhereAnalysisShouldFail(): iterable
+    {
+        $paths = [
+            'concrete-test-case-extending-abstract-test-case-without-test-suffix' => [
+                __DIR__ . '/../../../../Fixture/Classes/PHPUnit/Framework/TestCaseWithSuffixRule/Failure/ConcreteTestCaseExtendingAbstractTestCaseWithoutTestSuffix.php',
+                [
+                    \sprintf(
+                        'Class %s extends %s, is concrete, but does not have a Test suffix.',
+                        Fixture\Classes\PHPUnit\Framework\TestCaseWithSuffixRule\Failure\ConcreteTestCaseExtendingAbstractTestCaseWithoutTestSuffix::class,
+                        Framework\TestCase::class
+                    ),
+                    12,
+                ],
+            ],
+            'concrete-test-case-without-test-suffix' => [
+                __DIR__ . '/../../../../Fixture/Classes/PHPUnit/Framework/TestCaseWithSuffixRule/Failure/ConcreteTestCaseWithoutTestSuffix.php',
+                [
+                    \sprintf(
+                        'Class %s extends %s, is concrete, but does not have a Test suffix.',
+                        Fixture\Classes\PHPUnit\Framework\TestCaseWithSuffixRule\Failure\ConcreteTestCaseWithoutTestSuffix::class,
+                        Framework\TestCase::class
+                    ),
+                    14,
+                ],
+            ],
+        ];
+
+        foreach ($paths as $description => [$path, $error]) {
+            yield $description => [
+                $path,
+                $error,
+            ];
+        }
+    }
+
+    protected function getRule(): Rule
+    {
+        return new TestCaseWithSuffixRule($this->createBroker());
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements `Classes\PHPUnit\Framework\TestCaseWithSuffixRule`, which reports an error when a concrete sub-class of `PHPUnit\Framework\TestCase` does not have a `Test` suffix