### PR TITLE
Fix: Use main as default branch name

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,7 +1,7 @@
 # https://github.com/probot/settings
 
 branches:
-  - name: "master"
+  - name: "main"
 
     # https://developer.github.com/v3/repos/branches/#remove-branch-protection
     # https://developer.github.com/v3/repos/branches/#update-branch-protection
@@ -83,7 +83,7 @@ repository:
   allow_rebase_merge: false
   allow_squash_merge: false
   archived: false
-  default_branch: "master"
+  default_branch: "main"
   delete_branch_on_merge: true
   description: ":eyeglasses: Provides additional rules for phpstan/phpstan."
   has_downloads: true

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -6,7 +6,7 @@ on: # yamllint disable-line rule:truthy
   pull_request: null
   push:
     branches:
-      - "master"
+      - "main"
 
 env:
   MIN_COVERED_MSI: 92

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.15.0...master`][0.15.0...master].
+For a full diff see [`0.15.0...main`][0.15.0...main].
 
 ## [`0.15.0`][0.15.0]
 
@@ -348,7 +348,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [0.14.2...0.14.3]: https://github.com/ergebnis/phpstan-rules/compare/0.14.2...0.14.3
 [0.14.3...0.14.4]: https://github.com/ergebnis/phpstan-rules/compare/0.14.3...0.14.4
 [0.14.4...0.15.0]: https://github.com/ergebnis/phpstan-rules/compare/0.14.4...0.15.0
-[0.15.0...master]: https://github.com/ergebnis/phpstan-rules/compare/0.15.0...master
+[0.15.0...main]: https://github.com/ergebnis/phpstan-rules/compare/0.15.0...main
 
 [#1]: https://github.com/ergebnis/phpstan-rules/pull/1
 [#4]: https://github.com/ergebnis/phpstan-rules/pull/4

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # phpstan-rules
 
-[![Integrate](https://github.com/ergebnis/phpstan-rules/workflows/Integrate/badge.svg?branch=master)](https://github.com/ergebnis/phpstan-rules/actions)
-[![Prune](https://github.com/ergebnis/phpstan-rules/workflows/Prune/badge.svg?branch=master)](https://github.com/ergebnis/phpstan-rules/actions)
-[![Release](https://github.com/ergebnis/phpstan-rules/workflows/Release/badge.svg?branch=master)](https://github.com/ergebnis/phpstan-rules/actions)
-[![Renew](https://github.com/ergebnis/phpstan-rules/workflows/Renew/badge.svg?branch=master)](https://github.com/ergebnis/phpstan-rules/actions)
+[![Integrate](https://github.com/ergebnis/phpstan-rules/workflows/Integrate/badge.svg?branch=main)](https://github.com/ergebnis/phpstan-rules/actions)
+[![Prune](https://github.com/ergebnis/phpstan-rules/workflows/Prune/badge.svg?branch=main)](https://github.com/ergebnis/phpstan-rules/actions)
+[![Release](https://github.com/ergebnis/phpstan-rules/workflows/Release/badge.svg?branch=main)](https://github.com/ergebnis/phpstan-rules/actions)
+[![Renew](https://github.com/ergebnis/phpstan-rules/workflows/Renew/badge.svg?branch=main)](https://github.com/ergebnis/phpstan-rules/actions)
 
-[![Code Coverage](https://codecov.io/gh/ergebnis/phpstan-rules/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/phpstan-rules)
+[![Code Coverage](https://codecov.io/gh/ergebnis/phpstan-rules/branch/main/graph/badge.svg)](https://codecov.io/gh/ergebnis/phpstan-rules)
 [![Type Coverage](https://shepherd.dev/github/ergebnis/phpstan-rules/coverage.svg)](https://shepherd.dev/github/ergebnis/phpstan-rules)
 
 [![Latest Stable Version](https://poser.pugx.org/ergebnis/phpstan-rules/v/stable)](https://packagist.org/packages/ergebnis/phpstan-rules)
@@ -268,7 +268,7 @@ Please have a look at [`CONTRIBUTING.md`](.github/CONTRIBUTING.md).
 
 ## Code of Conduct
 
-Please have a look at [`CODE_OF_CONDUCT.md`](https://github.com/ergebnis/.github/blob/master/CODE_OF_CONDUCT.md).
+Please have a look at [`CODE_OF_CONDUCT.md`](https://github.com/ergebnis/.github/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 


### PR DESCRIPTION
This PR

* [x] uses `main` as default branch name

✊🏿 Black lives matter.