### PR TITLE
Methods\FinalInAbstractClassRule: allow __construct method to be non-final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.15.0...main`][0.15.0...main].
+For a full diff see [`0.15.1...main`][0.15.1...main].
+
+## [`0.15.1`][0.15.1]
+
+For a full diff see [`0.15.0...0.15.1`][0.15.0...0.15.1].
+
+### Changed
+
+* Adjusted `Methods\FinalInAbstractClass` rule to allow non-`final` `public` constructors in abstract classes ([#248]), by [@Slamdunk]
 
 ## [`0.15.0`][0.15.0]
 
@@ -323,6 +331,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [0.14.3]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.14.3
 [0.14.4]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.14.4
 [0.15.0]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.15.0
+[0.15.1]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.15.1
 
 [362c7ea...0.1.0]: https://github.com/ergebnis/phpstan-rules/compare/362c7ea...0.1.0
 [0.1.0...0.2.0]: https://github.com/ergebnis/phpstan-rules/compare/0.1.0...0.2.0
@@ -348,7 +357,8 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [0.14.2...0.14.3]: https://github.com/ergebnis/phpstan-rules/compare/0.14.2...0.14.3
 [0.14.3...0.14.4]: https://github.com/ergebnis/phpstan-rules/compare/0.14.3...0.14.4
 [0.14.4...0.15.0]: https://github.com/ergebnis/phpstan-rules/compare/0.14.4...0.15.0
-[0.15.0...main]: https://github.com/ergebnis/phpstan-rules/compare/0.15.0...main
+[0.15.0...0.15.1]: https://github.com/ergebnis/phpstan-rules/compare/0.15.0...0.15.1
+[0.15.1...main]: https://github.com/ergebnis/phpstan-rules/compare/0.15.1...main
 
 [#1]: https://github.com/ergebnis/phpstan-rules/pull/1
 [#4]: https://github.com/ergebnis/phpstan-rules/pull/4
@@ -398,7 +408,9 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [#186]: https://github.com/ergebnis/phpstan-rules/pull/186
 [#202]: https://github.com/ergebnis/phpstan-rules/pull/202
 [#225]: https://github.com/ergebnis/phpstan-rules/pull/225
+[#248]: https://github.com/ergebnis/phpstan-rules/pull/248
 
 [@ergebnis]: https://github.com/ergebnis
 [@Great-Antique]: https://github.com/Great-Antique
 [@localheinz]: https://github.com/localheinz
+[@Slamdunk]: https://github.com/Slamdunk

--- a/src/Methods/FinalInAbstractClassRule.php
+++ b/src/Methods/FinalInAbstractClassRule.php
@@ -59,6 +59,10 @@ final class FinalInAbstractClassRule implements Rule
             return [];
         }
 
+        if ('__construct' === $node->name->name) {
+            return [];
+        }
+
         return [
             \sprintf(
                 'Method %s::%s() is not final, but since the containing class is abstract, it should be.',

--- a/test/Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithNonFinalConstructor.php
+++ b/test/Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithNonFinalConstructor.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Success;
+
+abstract class AbstractClassWithNonFinalConstructor
+{
+    public function __construct()
+    {
+    }
+}

--- a/test/Integration/Methods/FinalInAbstractClassRuleTest.php
+++ b/test/Integration/Methods/FinalInAbstractClassRuleTest.php
@@ -31,6 +31,7 @@ final class FinalInAbstractClassRuleTest extends AbstractTestCase
             'abstract-class-with-abstract-method' => __DIR__ . '/../../Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithAbstractMethod.php',
             'abstract-class-with-final-protected-method' => __DIR__ . '/../../Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithFinalProtectedMethod.php',
             'abstract-class-with-final-public-method' => __DIR__ . '/../../Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithFinalPublicMethod.php',
+            'abstract-class-with-non-final-constructor' => __DIR__ . '/../../Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithNonFinalConstructor.php',
             'abstract-class-with-private-method' => __DIR__ . '/../../Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithPrivateMethod.php',
             'interface-with-public-method' => __DIR__ . '/../../Fixture/Methods/FinalInAbstractClassRule/Success/InterfaceWithPublicMethod.php',
         ];


### PR DESCRIPTION
This PR

* [x] Allow public `__construct` to be non-final, as the [template method pattern](https://slamdunk.github.io/blog/when-to-declare-methods-final/) cannot be leveraged for this specific method in a non-hacky form.

Related to #88, #123
