### PR TITLE
Fix: Drop support for PHP 7.1

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -15,13 +15,10 @@ branches:
       required_status_checks:
         contexts:
           - "Code Coverage (7.4, locked)"
-          - "Coding Standards (7.1, locked)"
+          - "Coding Standards (7.2, locked)"
           - "Dependency Analysis (7.4, locked)"
           - "Mutation Tests (7.4, locked)"
           - "Static Code Analysis (7.4, locked)"
-          - "Tests (7.1, highest)"
-          - "Tests (7.1, locked)"
-          - "Tests (7.1, lowest)"
           - "Tests (7.2, highest)"
           - "Tests (7.2, locked)"
           - "Tests (7.2, lowest)"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
+          - "7.2"
 
         dependencies:
           - "locked"
@@ -218,7 +218,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
           - "7.2"
           - "7.3"
           - "7.4"

--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
+          - "7.2"
 
         dependencies:
           - "locked"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.15.1...main`][0.15.1...main].
+For a full diff see [`0.15.2...main`][0.15.2...main].
+
+## [`0.15.2`][0.15.2]
+
+For a full diff see [`0.15.1...0.15.2`][0.15.1...0.15.2].
+
+### Changed
+
+* Dropped support for PHP 7.1 ([#259]), by [@localheinz]
 
 ## [`0.15.1`][0.15.1]
 
@@ -332,6 +340,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [0.14.4]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.14.4
 [0.15.0]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.15.0
 [0.15.1]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.15.1
+[0.15.2]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.15.2
 
 [362c7ea...0.1.0]: https://github.com/ergebnis/phpstan-rules/compare/362c7ea...0.1.0
 [0.1.0...0.2.0]: https://github.com/ergebnis/phpstan-rules/compare/0.1.0...0.2.0
@@ -358,7 +367,8 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [0.14.3...0.14.4]: https://github.com/ergebnis/phpstan-rules/compare/0.14.3...0.14.4
 [0.14.4...0.15.0]: https://github.com/ergebnis/phpstan-rules/compare/0.14.4...0.15.0
 [0.15.0...0.15.1]: https://github.com/ergebnis/phpstan-rules/compare/0.15.0...0.15.1
-[0.15.1...main]: https://github.com/ergebnis/phpstan-rules/compare/0.15.1...main
+[0.15.1...0.15.2]: https://github.com/ergebnis/phpstan-rules/compare/0.15.1...0.15.2
+[0.15.2...main]: https://github.com/ergebnis/phpstan-rules/compare/0.15.2...main
 
 [#1]: https://github.com/ergebnis/phpstan-rules/pull/1
 [#4]: https://github.com/ergebnis/phpstan-rules/pull/4
@@ -409,6 +419,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [#202]: https://github.com/ergebnis/phpstan-rules/pull/202
 [#225]: https://github.com/ergebnis/phpstan-rules/pull/225
 [#248]: https://github.com/ergebnis/phpstan-rules/pull/248
+[#259]: https://github.com/ergebnis/phpstan-rules/pull/259
 
 [@ergebnis]: https://github.com/ergebnis
 [@Great-Antique]: https://github.com/Great-Antique

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "php": "^7.1",
+    "php": "^7.2",
     "ext-mbstring": "*",
     "nikic/php-parser": "^4.2.3",
     "phpstan/phpstan": "~0.11.15 || ~0.12.0"
@@ -38,7 +38,7 @@
   },
   "config": {
     "platform": {
-      "php": "7.1.33"
+      "php": "7.2.33"
     },
     "preferred-install": "dist",
     "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "344e798d1bfe9f0cd1ec3885c13678c1",
+    "content-hash": "164e1164162b5db022eee16727818f58",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -5696,12 +5696,12 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1",
+        "php": "^7.2",
         "ext-mbstring": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1.33"
+        "php": "7.2.33"
     },
     "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
This PR

* [x] drops support for PHP 7.1

Related to https://github.com/ergebnis/composer-normalize/issues/529.