### PR TITLE
Enhancement: Allow installation with PHP 8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.15.2...main`][0.15.2...main].
+For a full diff see [`0.15.3...main`][0.15.3...main].
+
+## [`0.15.3`][0.15.3]
+
+For a full diff see [`0.15.2...0.15.3`][0.15.2...0.15.3].
+
+### Changed
+
+* Allow installation with PHP 8.0 ([#294]), by [@localheinz]
 
 ## [`0.15.2`][0.15.2]
 
@@ -341,6 +349,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [0.15.0]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.15.0
 [0.15.1]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.15.1
 [0.15.2]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.15.2
+[0.15.3]: https://github.com/ergebnis/phpstan-rules/releases/tag/0.15.3
 
 [362c7ea...0.1.0]: https://github.com/ergebnis/phpstan-rules/compare/362c7ea...0.1.0
 [0.1.0...0.2.0]: https://github.com/ergebnis/phpstan-rules/compare/0.1.0...0.2.0
@@ -368,7 +377,8 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [0.14.4...0.15.0]: https://github.com/ergebnis/phpstan-rules/compare/0.14.4...0.15.0
 [0.15.0...0.15.1]: https://github.com/ergebnis/phpstan-rules/compare/0.15.0...0.15.1
 [0.15.1...0.15.2]: https://github.com/ergebnis/phpstan-rules/compare/0.15.1...0.15.2
-[0.15.2...main]: https://github.com/ergebnis/phpstan-rules/compare/0.15.2...main
+[0.15.2...0.15.3]: https://github.com/ergebnis/phpstan-rules/compare/0.15.2...0.15.3
+[0.15.3...main]: https://github.com/ergebnis/phpstan-rules/compare/0.15.3...main
 
 [#1]: https://github.com/ergebnis/phpstan-rules/pull/1
 [#4]: https://github.com/ergebnis/phpstan-rules/pull/4
@@ -420,6 +430,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [#225]: https://github.com/ergebnis/phpstan-rules/pull/225
 [#248]: https://github.com/ergebnis/phpstan-rules/pull/248
 [#259]: https://github.com/ergebnis/phpstan-rules/pull/259
+[#294]: https://github.com/ergebnis/phpstan-rules/pull/294
 
 [@ergebnis]: https://github.com/ergebnis
 [@Great-Antique]: https://github.com/Great-Antique

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.2 || ^8.0",
     "ext-mbstring": "*",
     "nikic/php-parser": "^4.2.3",
     "phpstan/phpstan": "~0.11.15 || ~0.12.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5447d9f36dde9366a0d30828bf49bac0",
+    "content-hash": "331ea10e1dcd3cc58b81922270ec6c3f",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -5839,7 +5839,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "ext-mbstring": "*"
     },
     "platform-dev": [],


### PR DESCRIPTION
This PR

* [x] allows installation with PHP 8.0

Related to #285.

💁‍♂️ Will follow up with actually running builds on PHP 8.0 as well.