### PR TITLE
Fix: Use `--generate-baseline` option for generating baseline for `phpstan/phpstan`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ static-code-analysis: vendor ## Runs a static code analysis with phpstan/phpstan
 static-code-analysis-baseline: vendor ## Generates a baseline for static code analysis with phpstan/phpstan and vimeo/psalm
 	mkdir -p .build/phpstan
 	echo '' > phpstan-baseline.neon
-	vendor/bin/phpstan analyze --configuration=phpstan.neon --error-format=baselineNeon --memory-limit=-1 > phpstan-baseline.neon || true
+	vendor/bin/phpstan analyze --configuration=phpstan.neon --generate-baseline --memory-limit=-1
 	mkdir -p .build/psalm
 	vendor/bin/psalm --config=psalm.xml --set-baseline=psalm-baseline.xml
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,5 +1,3 @@
-
-
 parameters:
 	ignoreErrors:
 		-
@@ -23,6 +21,7 @@ parameters:
 			path: src/Functions/NoNullableReturnTypeDeclarationRule.php
 
 		-
-			message: "#^Parameter \\#1 \\$argument of class ReflectionClass constructor expects class-string<T of object>\\|T of object, string given\\.$#"
+			message: "#^Parameter \\#1 \\$argument of class ReflectionClass constructor expects class\\-string\\<T of object\\>\\|T of object, string given\\.$#"
 			count: 1
 			path: test/AutoReview/TestCodeTest.php
+


### PR DESCRIPTION
This pull request

* [x] uses the `--generate-baseline` option for generating the baseline for `phpstan/phpstan`
* [x] runs `make static-code-analysis-baseline`

Follows #381.