### PR TITLE
Remove unnecessary shell input symbol from installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Provides additional rules for [`phpstan/phpstan`](https://github.com/phpstan/php
 Run
 
 ```sh
-$ composer require --dev ergebnis/phpstan-rules
+composer require --dev ergebnis/phpstan-rules
 ```
 
 ## Usage


### PR DESCRIPTION
This pull request

- [x] Removes the shell input symbol from the installation instructions

This means a user can use the Copy button next to the code block on GitHub and paste the command into their terminal without getting an error.