### PR TITLE
Fix: Remove deprecated `checkMissingIterableValueType` option

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -20,8 +20,3 @@ parameters:
 			count: 1
 			path: src/Functions/NoNullableReturnTypeDeclarationRule.php
 
-		-
-			message: "#^Parameter \\#2 \\$expectedErrors of method PHPStan\\\\Testing\\\\RuleTestCase\\<PHPStan\\\\Rules\\\\Rule\\>\\:\\:analyse\\(\\) expects array\\<int, array\\{0\\: string, 1\\: int, 2\\?\\: string\\|null\\}\\>, array\\{array\\} given\\.$#"
-			count: 1
-			path: test/Integration/AbstractTestCase.php
-

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,6 @@ includes:
 	- rules.neon
 
 parameters:
-	checkMissingIterableValueType: false
 	checkGenericClassInNonGenericObjectType: false
 
 	ergebnis:

--- a/test/Integration/AbstractTestCase.php
+++ b/test/Integration/AbstractTestCase.php
@@ -31,6 +31,9 @@ abstract class AbstractTestCase extends RuleTestCase
         );
     }
 
+    /**
+     * @param array{0: string, 1: int} $error
+     */
     #[Framework\Attributes\DataProvider('provideCasesWhereAnalysisShouldFail')]
     final public function testAnalysisFails(string $path, array $error): void
     {
@@ -46,7 +49,13 @@ abstract class AbstractTestCase extends RuleTestCase
         );
     }
 
+    /**
+     * @return iterable<string, array{0: string}>
+     */
     abstract public static function provideCasesWhereAnalysisShouldSucceed(): iterable;
 
+    /**
+     * @return iterable<string, array{0: string, 1: array{0: string, 1: int}}>
+     */
     abstract public static function provideCasesWhereAnalysisShouldFail(): iterable;
 }


### PR DESCRIPTION
This pull request

- [x] removes the deprecated `checkMissingIterableValueType` option