### PR TITLE
Fix: Use `PhpParser\Node\Scalar\Int_` instead of `PhpParser\Node\Scalar\LNumber`

### DIFF
--- a/src/Files/DeclareStrictTypesRule.php
+++ b/src/Files/DeclareStrictTypesRule.php
@@ -62,7 +62,7 @@ final class DeclareStrictTypesRule implements Rules\Rule
             foreach ($firstNode->declares as $declare) {
                 if (
                     'strict_types' === $declare->key->toLowerString()
-                    && $declare->value instanceof Node\Scalar\LNumber
+                    && $declare->value instanceof Node\Scalar\Int_
                     && 1 === $declare->value->value
                 ) {
                     return [];


### PR DESCRIPTION
…Number

This pull request

- [x] uses `PhpParser\Node\Scalar\Int` instead of `PhpParser\Node\Scalar\LNumber`