### PR TITLE
Fix: Remove conditions that should never evaluate to true

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -31,7 +31,6 @@
     "PHPStan\\Rules\\Rule",
     "PHPStan\\Rules\\RuleError",
     "PHPStan\\Rules\\RuleErrorBuilder",
-    "PHPStan\\ShouldNotHappenException",
     "self",
     "string",
     "true"

--- a/src/Classes/FinalRule.php
+++ b/src/Classes/FinalRule.php
@@ -18,7 +18,6 @@ use PhpParser\Comment;
 use PhpParser\Node;
 use PHPStan\Analyser;
 use PHPStan\Rules;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * @implements Rules\Rule<Node\Stmt\Class_>
@@ -74,14 +73,6 @@ final class FinalRule implements Rules\Rule
         Node $node,
         Analyser\Scope $scope
     ): array {
-        if (!$node instanceof Node\Stmt\Class_) {
-            throw new ShouldNotHappenException(\sprintf(
-                'Expected node to be instance of "%s", but got instance of "%s" instead.',
-                Node\Stmt\Class_::class,
-                \get_class($node),
-            ));
-        }
-
         if (!isset($node->namespacedName)) {
             return [];
         }

--- a/src/Classes/NoExtendsRule.php
+++ b/src/Classes/NoExtendsRule.php
@@ -17,7 +17,6 @@ use Ergebnis\PHPStan\Rules\ErrorIdentifier;
 use PhpParser\Node;
 use PHPStan\Analyser;
 use PHPStan\Rules;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * @implements Rules\Rule<Node\Stmt\Class_>
@@ -59,14 +58,6 @@ final class NoExtendsRule implements Rules\Rule
         Node $node,
         Analyser\Scope $scope
     ): array {
-        if (!$node instanceof Node\Stmt\Class_) {
-            throw new ShouldNotHappenException(\sprintf(
-                'Expected node to be instance of "%s", but got instance of "%s" instead.',
-                Node\Stmt\Class_::class,
-                \get_class($node),
-            ));
-        }
-
         if (!$node->extends instanceof Node\Name) {
             return [];
         }

--- a/src/Classes/PHPUnit/Framework/TestCaseWithSuffixRule.php
+++ b/src/Classes/PHPUnit/Framework/TestCaseWithSuffixRule.php
@@ -18,7 +18,6 @@ use PhpParser\Node;
 use PHPStan\Analyser;
 use PHPStan\Reflection;
 use PHPStan\Rules;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * @implements Rules\Rule<Node\Stmt\Class_>
@@ -47,14 +46,6 @@ final class TestCaseWithSuffixRule implements Rules\Rule
         Node $node,
         Analyser\Scope $scope
     ): array {
-        if (!$node instanceof Node\Stmt\Class_) {
-            throw new ShouldNotHappenException(\sprintf(
-                'Expected node to be instance of "%s", but got instance of "%s" instead.',
-                Node\Stmt\Class_::class,
-                \get_class($node),
-            ));
-        }
-
         if ($node->isAbstract()) {
             return [];
         }

--- a/src/Closures/NoNullableReturnTypeDeclarationRule.php
+++ b/src/Closures/NoNullableReturnTypeDeclarationRule.php
@@ -17,7 +17,6 @@ use Ergebnis\PHPStan\Rules\ErrorIdentifier;
 use PhpParser\Node;
 use PHPStan\Analyser;
 use PHPStan\Rules;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * @implements Rules\Rule<Node\Expr\Closure>
@@ -33,14 +32,6 @@ final class NoNullableReturnTypeDeclarationRule implements Rules\Rule
         Node $node,
         Analyser\Scope $scope
     ): array {
-        if (!$node instanceof Node\Expr\Closure) {
-            throw new ShouldNotHappenException(\sprintf(
-                'Expected node to be instance of "%s", but got instance of "%s" instead.',
-                Node\Expr\Closure::class,
-                \get_class($node),
-            ));
-        }
-
         if (!self::hasNullableReturnType($node)) {
             return [];
         }

--- a/src/Closures/NoParameterWithNullDefaultValueRule.php
+++ b/src/Closures/NoParameterWithNullDefaultValueRule.php
@@ -17,7 +17,6 @@ use Ergebnis\PHPStan\Rules\ErrorIdentifier;
 use PhpParser\Node;
 use PHPStan\Analyser;
 use PHPStan\Rules;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * @implements Rules\Rule<Node\Expr\Closure>
@@ -33,14 +32,6 @@ final class NoParameterWithNullDefaultValueRule implements Rules\Rule
         Node $node,
         Analyser\Scope $scope
     ): array {
-        if (!$node instanceof Node\Expr\Closure) {
-            throw new ShouldNotHappenException(\sprintf(
-                'Expected node to be instance of "%s", but got instance of "%s" instead.',
-                Node\Expr\Closure::class,
-                \get_class($node),
-            ));
-        }
-
         if (0 === \count($node->params)) {
             return [];
         }

--- a/src/Closures/NoParameterWithNullableTypeDeclarationRule.php
+++ b/src/Closures/NoParameterWithNullableTypeDeclarationRule.php
@@ -17,7 +17,6 @@ use Ergebnis\PHPStan\Rules\ErrorIdentifier;
 use PhpParser\Node;
 use PHPStan\Analyser;
 use PHPStan\Rules;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * @implements Rules\Rule<Node\Expr\Closure>
@@ -33,14 +32,6 @@ final class NoParameterWithNullableTypeDeclarationRule implements Rules\Rule
         Node $node,
         Analyser\Scope $scope
     ): array {
-        if (!$node instanceof Node\Expr\Closure) {
-            throw new ShouldNotHappenException(\sprintf(
-                'Expected node to be instance of "%s", but got instance of "%s" instead.',
-                Node\Expr\Closure::class,
-                \get_class($node),
-            ));
-        }
-
         if (0 === \count($node->params)) {
             return [];
         }

--- a/src/Expressions/NoCompactRule.php
+++ b/src/Expressions/NoCompactRule.php
@@ -17,7 +17,6 @@ use Ergebnis\PHPStan\Rules\ErrorIdentifier;
 use PhpParser\Node;
 use PHPStan\Analyser;
 use PHPStan\Rules;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * @implements Rules\Rule<Node\Expr\FuncCall>
@@ -33,14 +32,6 @@ final class NoCompactRule implements Rules\Rule
         Node $node,
         Analyser\Scope $scope
     ): array {
-        if (!$node instanceof Node\Expr\FuncCall) {
-            throw new ShouldNotHappenException(\sprintf(
-                'Expected node to be instance of "%s", but got instance of "%s" instead.',
-                Node\Expr\FuncCall::class,
-                \get_class($node),
-            ));
-        }
-
         if (!$node->name instanceof Node\Name) {
             return [];
         }

--- a/src/Files/DeclareStrictTypesRule.php
+++ b/src/Files/DeclareStrictTypesRule.php
@@ -18,7 +18,6 @@ use PhpParser\Node;
 use PHPStan\Analyser;
 use PHPStan\Node\FileNode;
 use PHPStan\Rules;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * @implements Rules\Rule<FileNode>
@@ -34,14 +33,6 @@ final class DeclareStrictTypesRule implements Rules\Rule
         Node $node,
         Analyser\Scope $scope
     ): array {
-        if (!$node instanceof FileNode) {
-            throw new ShouldNotHappenException(\sprintf(
-                'Expected node to be instance of "%s", but got instance of "%s" instead.',
-                FileNode::class,
-                \get_class($node),
-            ));
-        }
-
         $nodes = $node->getNodes();
 
         if (0 === \count($nodes)) {

--- a/src/Functions/NoNullableReturnTypeDeclarationRule.php
+++ b/src/Functions/NoNullableReturnTypeDeclarationRule.php
@@ -17,7 +17,6 @@ use Ergebnis\PHPStan\Rules\ErrorIdentifier;
 use PhpParser\Node;
 use PHPStan\Analyser;
 use PHPStan\Rules;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * @implements Rules\Rule<Node\Stmt\Function_>
@@ -33,14 +32,6 @@ final class NoNullableReturnTypeDeclarationRule implements Rules\Rule
         Node $node,
         Analyser\Scope $scope
     ): array {
-        if (!$node instanceof Node\Stmt\Function_) {
-            throw new ShouldNotHappenException(\sprintf(
-                'Expected node to be instance of "%s", but got instance of "%s" instead.',
-                Node\Stmt\Function_::class,
-                \get_class($node),
-            ));
-        }
-
         if (!isset($node->namespacedName)) {
             return [];
         }

--- a/src/Functions/NoParameterWithNullDefaultValueRule.php
+++ b/src/Functions/NoParameterWithNullDefaultValueRule.php
@@ -17,7 +17,6 @@ use Ergebnis\PHPStan\Rules\ErrorIdentifier;
 use PhpParser\Node;
 use PHPStan\Analyser;
 use PHPStan\Rules;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * @implements Rules\Rule<Node\Stmt\Function_>
@@ -33,14 +32,6 @@ final class NoParameterWithNullDefaultValueRule implements Rules\Rule
         Node $node,
         Analyser\Scope $scope
     ): array {
-        if (!$node instanceof Node\Stmt\Function_) {
-            throw new ShouldNotHappenException(\sprintf(
-                'Expected node to be instance of "%s", but got instance of "%s" instead.',
-                Node\Stmt\Function_::class,
-                \get_class($node),
-            ));
-        }
-
         if (0 === \count($node->params)) {
             return [];
         }

--- a/src/Functions/NoParameterWithNullableTypeDeclarationRule.php
+++ b/src/Functions/NoParameterWithNullableTypeDeclarationRule.php
@@ -17,7 +17,6 @@ use Ergebnis\PHPStan\Rules\ErrorIdentifier;
 use PhpParser\Node;
 use PHPStan\Analyser;
 use PHPStan\Rules;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * @implements Rules\Rule<Node\Stmt\Function_>
@@ -33,14 +32,6 @@ final class NoParameterWithNullableTypeDeclarationRule implements Rules\Rule
         Node $node,
         Analyser\Scope $scope
     ): array {
-        if (!$node instanceof Node\Stmt\Function_) {
-            throw new ShouldNotHappenException(\sprintf(
-                'Expected node to be instance of "%s", but got instance of "%s" instead.',
-                Node\Stmt\Function_::class,
-                \get_class($node),
-            ));
-        }
-
         if (0 === \count($node->params)) {
             return [];
         }

--- a/src/Methods/FinalInAbstractClassRule.php
+++ b/src/Methods/FinalInAbstractClassRule.php
@@ -18,7 +18,6 @@ use PhpParser\Node;
 use PHPStan\Analyser;
 use PHPStan\Reflection;
 use PHPStan\Rules;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * @implements Rules\Rule<Node\Stmt\ClassMethod>
@@ -34,14 +33,6 @@ final class FinalInAbstractClassRule implements Rules\Rule
         Node $node,
         Analyser\Scope $scope
     ): array {
-        if (!$node instanceof Node\Stmt\ClassMethod) {
-            throw new ShouldNotHappenException(\sprintf(
-                'Expected node to be instance of "%s", but got instance of "%s" instead.',
-                Node\Stmt\ClassMethod::class,
-                \get_class($node),
-            ));
-        }
-
         /** @var Reflection\ClassReflection $containingClass */
         $containingClass = $scope->getClassReflection();
 

--- a/src/Methods/NoConstructorParameterWithDefaultValueRule.php
+++ b/src/Methods/NoConstructorParameterWithDefaultValueRule.php
@@ -18,7 +18,6 @@ use PhpParser\Node;
 use PHPStan\Analyser;
 use PHPStan\Reflection;
 use PHPStan\Rules;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * @implements Rules\Rule<Node\Stmt\ClassMethod>
@@ -34,14 +33,6 @@ final class NoConstructorParameterWithDefaultValueRule implements Rules\Rule
         Node $node,
         Analyser\Scope $scope
     ): array {
-        if (!$node instanceof Node\Stmt\ClassMethod) {
-            throw new ShouldNotHappenException(\sprintf(
-                'Expected node to be instance of "%s", but got instance of "%s" instead.',
-                Node\Stmt\ClassMethod::class,
-                \get_class($node),
-            ));
-        }
-
         if ('__construct' !== $node->name->toLowerString()) {
             return [];
         }

--- a/src/Methods/NoNullableReturnTypeDeclarationRule.php
+++ b/src/Methods/NoNullableReturnTypeDeclarationRule.php
@@ -18,7 +18,6 @@ use PhpParser\Node;
 use PHPStan\Analyser;
 use PHPStan\Reflection;
 use PHPStan\Rules;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * @implements Rules\Rule<Node\Stmt\ClassMethod>
@@ -34,14 +33,6 @@ final class NoNullableReturnTypeDeclarationRule implements Rules\Rule
         Node $node,
         Analyser\Scope $scope
     ): array {
-        if (!$node instanceof Node\Stmt\ClassMethod) {
-            throw new ShouldNotHappenException(\sprintf(
-                'Expected node to be instance of "%s", but got instance of "%s" instead.',
-                Node\Stmt\ClassMethod::class,
-                \get_class($node),
-            ));
-        }
-
         if (!self::hasNullableReturnType($node)) {
             return [];
         }

--- a/src/Methods/NoParameterWithContainerTypeDeclarationRule.php
+++ b/src/Methods/NoParameterWithContainerTypeDeclarationRule.php
@@ -18,7 +18,6 @@ use PhpParser\Node;
 use PHPStan\Analyser;
 use PHPStan\Reflection;
 use PHPStan\Rules;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * @implements Rules\Rule<Node\Stmt\ClassMethod>
@@ -67,14 +66,6 @@ final class NoParameterWithContainerTypeDeclarationRule implements Rules\Rule
         Node $node,
         Analyser\Scope $scope
     ): array {
-        if (!$node instanceof Node\Stmt\ClassMethod) {
-            throw new ShouldNotHappenException(\sprintf(
-                'Expected node to be instance of "%s", but got instance of "%s" instead.',
-                Node\Stmt\ClassMethod::class,
-                \get_class($node),
-            ));
-        }
-
         if (0 === \count($this->interfacesImplementedByContainers)) {
             return [];
         }

--- a/src/Methods/NoParameterWithNullDefaultValueRule.php
+++ b/src/Methods/NoParameterWithNullDefaultValueRule.php
@@ -18,7 +18,6 @@ use PhpParser\Node;
 use PHPStan\Analyser;
 use PHPStan\Reflection;
 use PHPStan\Rules;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * @implements Rules\Rule<Node\Stmt\ClassMethod>
@@ -34,14 +33,6 @@ final class NoParameterWithNullDefaultValueRule implements Rules\Rule
         Node $node,
         Analyser\Scope $scope
     ): array {
-        if (!$node instanceof Node\Stmt\ClassMethod) {
-            throw new ShouldNotHappenException(\sprintf(
-                'Expected node to be instance of "%s", but got instance of "%s" instead.',
-                Node\Stmt\ClassMethod::class,
-                \get_class($node),
-            ));
-        }
-
         if (0 === \count($node->params)) {
             return [];
         }

--- a/src/Methods/NoParameterWithNullableTypeDeclarationRule.php
+++ b/src/Methods/NoParameterWithNullableTypeDeclarationRule.php
@@ -18,7 +18,6 @@ use PhpParser\Node;
 use PHPStan\Analyser;
 use PHPStan\Reflection;
 use PHPStan\Rules;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * @implements Rules\Rule<Node\Stmt\ClassMethod>
@@ -34,14 +33,6 @@ final class NoParameterWithNullableTypeDeclarationRule implements Rules\Rule
         Node $node,
         Analyser\Scope $scope
     ): array {
-        if (!$node instanceof Node\Stmt\ClassMethod) {
-            throw new ShouldNotHappenException(\sprintf(
-                'Expected node to be instance of "%s", but got instance of "%s" instead.',
-                Node\Stmt\ClassMethod::class,
-                \get_class($node),
-            ));
-        }
-
         if (0 === \count($node->params)) {
             return [];
         }

--- a/src/Methods/PrivateInFinalClassRule.php
+++ b/src/Methods/PrivateInFinalClassRule.php
@@ -18,7 +18,6 @@ use PhpParser\Node;
 use PHPStan\Analyser;
 use PHPStan\Reflection;
 use PHPStan\Rules;
-use PHPStan\ShouldNotHappenException;
 
 /**
  * @implements Rules\Rule<Node\Stmt\ClassMethod>
@@ -34,14 +33,6 @@ final class PrivateInFinalClassRule implements Rules\Rule
         Node $node,
         Analyser\Scope $scope
     ): array {
-        if (!$node instanceof Node\Stmt\ClassMethod) {
-            throw new ShouldNotHappenException(\sprintf(
-                'Expected node to be instance of "%s", but got instance of "%s" instead.',
-                Node\Stmt\ClassMethod::class,
-                \get_class($node),
-            ));
-        }
-
         /** @var Reflection\ClassReflection $containingClass */
         $containingClass = $scope->getClassReflection();
 


### PR DESCRIPTION
This pull request

- [x] removes conditions that should never evaluate to `true`