### PR TITLE
Fix: Return `RuleError` with identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.5.0...main`][2.5.0...main].
 
+### Fixed
+
+- Returned rule with error identifier ([#882]), by [@localheinz]
+
 ## [`2.5.0`][2.5.0]
 
 For a full diff see [`2.4.0...2.5.0`][2.4.0...2.5.0].
@@ -543,6 +547,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [#877]: https://github.com/ergebnis/phpstan-rules/pull/877
 [#878]: https://github.com/ergebnis/phpstan-rules/pull/878
 [#880]: https://github.com/ergebnis/phpstan-rules/pull/880
+[#882]: https://github.com/ergebnis/phpstan-rules/pull/882
 
 [@enumag]: https://github.com/enumag
 [@ergebnis]: https://github.com/ergebnis

--- a/src/Methods/NoConstructorParameterWithDefaultValueRule.php
+++ b/src/Methods/NoConstructorParameterWithDefaultValueRule.php
@@ -71,18 +71,20 @@ final class NoConstructorParameterWithDefaultValueRule implements Rules\Rule
 
         $className = $classReflection->getName();
 
-        return \array_values(\array_map(static function (Node\Param $node) use ($className): string {
+        return \array_values(\array_map(static function (Node\Param $node) use ($className): Rules\RuleError {
             /** @var Node\Expr\Variable $variable */
             $variable = $node->var;
 
             /** @var string $parameterName */
             $parameterName = $variable->name;
 
-            return \sprintf(
+            $ruleErrorBuilder = Rules\RuleErrorBuilder::message(\sprintf(
                 'Constructor in %s has parameter $%s with default value.',
                 $className,
                 $parameterName,
-            );
+            ));
+
+            return $ruleErrorBuilder->identifier(ErrorIdentifier::noConstructorParameterWithDefaultValue()->toString())->build();
         }, $params));
     }
 }


### PR DESCRIPTION
This pull request

- [x] returns a `RuleError` with identifier

Follows #876.
Related to #873.