### PR TITLE
Fix: Adjust `NoCompactRule` to detect usages of `compact()` with incorrect case

### DIFF
--- a/.php-cs-fixer.fixture.php
+++ b/.php-cs-fixer.fixture.php
@@ -25,6 +25,7 @@ $ruleSet = PhpCsFixer\Config\RuleSet\Php74::create()
         'header_comment' => false,
         'lowercase_keywords' => false,
         'magic_method_casing' => false,
+        'native_function_casing' => false,
         'nullable_type_declaration' => false,
         'protected_to_private' => false,
         'static_lambda' => false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`2.5.0...main`][2.5.0...main].
 
 - Returned rule with error identifier ([#882]), by [@localheinz]
 - Adjusted `Methods\FinalInAbstractClassRule` to ignore Doctrine embeddables and entities ([#396]), by [@localheinz]
+- Adjusted `Exprsssions\NoCompactRule` to detect usages of `compact()` with incorrect case ([#889]), by [@localheinz]
 
 ## [`2.5.0`][2.5.0]
 

--- a/src/Expressions/NoCompactRule.php
+++ b/src/Expressions/NoCompactRule.php
@@ -36,7 +36,7 @@ final class NoCompactRule implements Rules\Rule
             return [];
         }
 
-        if ('compact' !== $scope->resolveName($node->name)) {
+        if ('compact' !== \mb_strtolower($scope->resolveName($node->name))) {
             return [];
         }
 

--- a/test/Fixture/Expressions/NoCompactRule/Failure/compact-used-with-incorrect-case.php
+++ b/test/Fixture/Expressions/NoCompactRule/Failure/compact-used-with-incorrect-case.php
@@ -7,7 +7,7 @@ namespace Ergebnis\PHPStan\Rules\Test\Fixture\Expressions\NoCompactRule\Failure;
 $foo = 9000;
 $bar = 42;
 
-return \compact(
+return \cOmPaCt(
     'foo',
     'bar',
 );


### PR DESCRIPTION
This pull request

- [x] keeps using `compact()` with incorrect case in a test case for the `NoCompactRule`
- [x] adjusts the `NoCompactRule` to detect usages of `compact()` with incorrect case