### PR TITLE
Fix: Do not require methods with `phpunit/phpunit` annotations to be `private`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For a full diff see [`2.5.0...main`][2.5.0...main].
 - Adjusted `Methods\PrivateInFinalClassRule` to use more appropriate message when detecting a `protected` method in an anonymous class ([#890]), by [@localheinz]
 - Adjusted `Methods\PrivateInFinalClassRule` to ignore `protected` methods from traits ([#891]), by [@localheinz]
 - Adjusted `Methods\PrivateInFinalClassRule` to ignore `protected` methods with `phpunit/phpunit` attributes requiring methods to be `protected` ([#863]), by [@cosmastech]
+- Adjusted `Methods\PrivateInFinalClassRule` to ignore `protected` methods with `phpunit/phpunit` annotations requiring methods to be `protected` ([#895]), by [@cosmastech]
 
 ## [`2.5.0`][2.5.0]
 
@@ -558,6 +559,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [#889]: https://github.com/ergebnis/phpstan-rules/pull/889
 [#890]: https://github.com/ergebnis/phpstan-rules/pull/890
 [#891]: https://github.com/ergebnis/phpstan-rules/pull/891
+[#895]: https://github.com/ergebnis/phpstan-rules/pull/895
 
 [@enumag]: https://github.com/enumag
 [@cosmastech]: https://github.com/cosmastech

--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -33,6 +33,7 @@
     "PHPStan\\Rules\\Rule",
     "PHPStan\\Rules\\RuleError",
     "PHPStan\\Rules\\RuleErrorBuilder",
+    "PHPStan\\Type\\FileTypeMapper",
     "PHPUnit\\Framework\\Attributes\\After",
     "PHPUnit\\Framework\\Attributes\\Before",
     "PHPUnit\\Framework\\Attributes\\PostCondition",

--- a/test/Fixture/Methods/PrivateInFinalClassRule/FinalClassWithProtectedMethodsWithPhpUnitAnnotations.php
+++ b/test/Fixture/Methods/PrivateInFinalClassRule/FinalClassWithProtectedMethodsWithPhpUnitAnnotations.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule;
+
+use PHPUnit\Framework;
+
+final class FinalClassWithProtectedMethodsWithPhpUnitAnnotations extends Framework\TestCase
+{
+    /**
+     * @after
+     */
+    protected function methodWithAfterAnnotation(): void
+    {
+    }
+
+    /**
+     * @before
+     */
+    protected function methodWithBeforeAnnotation(): void
+    {
+    }
+
+    /**
+     * @preCondition
+     */
+    protected function methodWithPreConditionAnnotation(): void
+    {
+    }
+
+    /**
+     * @postCondition
+     */
+    protected function methodWithPostConditionAnnotation(): void
+    {
+    }
+}

--- a/test/Integration/Methods/PrivateInFinalClassRuleTest.php
+++ b/test/Integration/Methods/PrivateInFinalClassRuleTest.php
@@ -17,6 +17,7 @@ use Ergebnis\PHPStan\Rules\Methods;
 use Ergebnis\PHPStan\Rules\Test;
 use PHPStan\Rules;
 use PHPStan\Testing;
+use PHPStan\Type;
 
 /**
  * @covers \Ergebnis\PHPStan\Rules\Methods\PrivateInFinalClassRule
@@ -51,6 +52,8 @@ final class PrivateInFinalClassRuleTest extends Testing\RuleTestCase
 
     protected function getRule(): Rules\Rule
     {
-        return new Methods\PrivateInFinalClassRule();
+        $fileTypeMapper = self::getContainer()->getByType(Type\FileTypeMapper::class);
+
+        return new Methods\PrivateInFinalClassRule($fileTypeMapper);
     }
 }


### PR DESCRIPTION
This pull request

- [x] stops requiring methods with `phpunit/phpunit` annotations to be `private`

Follows #863.