### PR TITLE
Fix: Detect cases where `null` is referenced with incorrect case or relative to the root namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.5.1...main`][2.5.1...main].
 
+### Fixed
+
+- Adjusted `Closures\NoNullableReturnTypeDeclarationRule`, `Closures\NoParameterWithNullableTypeDeclarationRule`, `Functions\NoNullableReturnTypeDeclarationRule`, `Functions\NoParameterWithNullableTypeDeclarationRule`, `Methods\NoNullableReturnTypeDeclarationRule`, `Methods\NoParameterWithNullableTypeDeclarationRule` to detect cases where `null` is referenced with incorrect case or relative to the root namespace ([#897]), by [@localheinz]
+
 ## [`2.5.1`][2.5.1]
 
 For a full diff see [`2.5.0...2.5.1`][2.5.0...2.5.1].
@@ -566,6 +570,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [#890]: https://github.com/ergebnis/phpstan-rules/pull/890
 [#891]: https://github.com/ergebnis/phpstan-rules/pull/891
 [#895]: https://github.com/ergebnis/phpstan-rules/pull/895
+[#897]: https://github.com/ergebnis/phpstan-rules/pull/897
 
 [@enumag]: https://github.com/enumag
 [@cosmastech]: https://github.com/cosmastech

--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -15,6 +15,7 @@
     "PhpParser\\Node\\Expr\\Isset_",
     "PhpParser\\Node\\Identifier",
     "PhpParser\\Node\\Name",
+    "PhpParser\\Node\\Name\\FullyQualified",
     "PhpParser\\Node\\NullableType",
     "PhpParser\\Node\\Param",
     "PhpParser\\Node\\Scalar\\LNumber",

--- a/src/Analyzer.php
+++ b/src/Analyzer.php
@@ -40,11 +40,17 @@ final class Analyzer
 
         if ($typeDeclaration instanceof Node\UnionType) {
             foreach ($typeDeclaration->types as $type) {
-                if (!$type instanceof Node\Identifier) {
-                    continue;
+                if (
+                    $type instanceof Node\Identifier
+                    && 'null' === $type->toLowerString()
+                ) {
+                    return true;
                 }
 
-                if ('null' === $type->toLowerString()) {
+                if (
+                    $type instanceof Node\Name\FullyQualified
+                    && 'null' === $type->toLowerString()
+                ) {
                     return true;
                 }
             }

--- a/test/Integration/Closures/NoNullableReturnTypeDeclarationRuleTest.php
+++ b/test/Integration/Closures/NoNullableReturnTypeDeclarationRuleTest.php
@@ -48,6 +48,10 @@ final class NoNullableReturnTypeDeclarationRuleTest extends Testing\RuleTestCase
                     'Closure has a nullable return type declaration.',
                     23,
                 ],
+                [
+                    'Closure has a nullable return type declaration.',
+                    27,
+                ],
             ],
         );
     }

--- a/test/Integration/Closures/NoParameterWithNullableTypeDeclarationRuleTest.php
+++ b/test/Integration/Closures/NoParameterWithNullableTypeDeclarationRuleTest.php
@@ -48,6 +48,10 @@ final class NoParameterWithNullableTypeDeclarationRuleTest extends Testing\RuleT
                     'Closure has parameter $bar with a nullable type declaration.',
                     26,
                 ],
+                [
+                    'Closure has parameter $bar with a nullable type declaration.',
+                    30,
+                ],
             ],
         );
     }

--- a/test/Integration/Functions/NoNullableReturnTypeDeclarationRuleTest.php
+++ b/test/Integration/Functions/NoNullableReturnTypeDeclarationRuleTest.php
@@ -48,6 +48,10 @@ final class NoNullableReturnTypeDeclarationRuleTest extends Testing\RuleTestCase
                     'Function Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoNullableReturnTypeDeclarationRule\quz() has a nullable return type declaration.',
                     27,
                 ],
+                [
+                    'Function Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoNullableReturnTypeDeclarationRule\corge() has a nullable return type declaration.',
+                    32,
+                ],
             ],
         );
     }

--- a/test/Integration/Functions/NoParameterWithNullableTypeDeclarationRuleTest.php
+++ b/test/Integration/Functions/NoParameterWithNullableTypeDeclarationRuleTest.php
@@ -48,6 +48,10 @@ final class NoParameterWithNullableTypeDeclarationRuleTest extends Testing\RuleT
                     'Function Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullableTypeDeclarationRule\quz() has parameter $bar with a nullable type declaration.',
                     31,
                 ],
+                [
+                    'Function Ergebnis\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullableTypeDeclarationRule\corge() has parameter $bar with a nullable type declaration.',
+                    36,
+                ],
             ],
         );
     }

--- a/test/Integration/Methods/NoNullableReturnTypeDeclarationRuleTest.php
+++ b/test/Integration/Methods/NoNullableReturnTypeDeclarationRuleTest.php
@@ -76,6 +76,10 @@ final class NoNullableReturnTypeDeclarationRuleTest extends Testing\RuleTestCase
                     'Method toString() in anonymous class has a nullable return type declaration.',
                     36,
                 ],
+                [
+                    'Method toString() in anonymous class has a nullable return type declaration.',
+                    43,
+                ],
             ],
         );
     }

--- a/test/Integration/Methods/NoParameterWithNullableTypeDeclarationRuleTest.php
+++ b/test/Integration/Methods/NoParameterWithNullableTypeDeclarationRuleTest.php
@@ -76,6 +76,10 @@ final class NoParameterWithNullableTypeDeclarationRuleTest extends Testing\RuleT
                     'Method foo() in anonymous class has parameter $bar with a nullable type declaration.',
                     42,
                 ],
+                [
+                    'Method foo() in anonymous class has parameter $bar with a nullable type declaration.',
+                    49,
+                ],
             ],
         );
     }


### PR DESCRIPTION
This pull request

- [x] adjusts the `Analyzer` to detect cases where `null` is referenced with incorrect case or relative to the root namespace