### PR TITLE
Enhancement: Extract `allRules` parameter to allow disabling and enabling all rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.7.0...main`][2.7.0...main].
 
+### Added
+
+- Added `allRules` parameter to allow disabling and enabling all rules  ([#913]), by [@localheinz]
+
 ## [`2.7.0`][2.7.0]
 
 For a full diff see [`2.6.1...2.7.0`][2.6.1...2.7.0].
@@ -612,6 +616,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [#902]: https://github.com/ergebnis/phpstan-rules/pull/902
 [#911]: https://github.com/ergebnis/phpstan-rules/pull/911
 [#912]: https://github.com/ergebnis/phpstan-rules/pull/912
+[#913]: https://github.com/ergebnis/phpstan-rules/pull/913
 
 [@cosmastech]: https://github.com/cosmastech
 [@enumag]: https://github.com/enumag

--- a/README.md
+++ b/README.md
@@ -604,6 +604,28 @@ parameters:
 			enabled: false
 ```
 
+## Disabling all rules
+
+You can disable all rules using the `allRules` configuration parameter:
+
+```neon
+parameters:
+	ergebnis:
+		allRules: false
+```
+
+## Enabling rules one-by-one
+
+If you have disabled all rules using the `allRules` configuration parameter, you can re-enable individual rules with their corresponding configuration parameters:
+
+```neon
+parameters:
+	ergebnis:
+		allRules: false
+		privateInFinalClass:
+			enabled: true
+```
+
 ## Changelog
 
 The maintainers of this project record notable changes to this project in a [changelog](CHANGELOG.md).

--- a/rules.neon
+++ b/rules.neon
@@ -54,51 +54,53 @@ conditionalTags:
 
 parameters:
 	ergebnis:
+		allRules: true
 		declareStrictTypes:
-			enabled: true
+			enabled: %ergebnis.allRules%
 		final:
 			allowAbstractClasses: true
 			classesNotRequiredToBeAbstractOrFinal: []
-			enabled: true
+			enabled: %ergebnis.allRules%
 		finalInAbstractClass:
-			enabled: true
+			enabled: %ergebnis.allRules%
 		noCompact:
-			enabled: true
+			enabled: %ergebnis.allRules%
 		noConstructorParameterWithDefaultValue:
-			enabled: true
+			enabled: %ergebnis.allRules%
 		noErrorSuppression:
-			enabled: true
+			enabled: %ergebnis.allRules%
 		noEval:
-			enabled: true
+			enabled: %ergebnis.allRules%
 		noExtends:
 			classesAllowedToBeExtended: []
-			enabled: true
+			enabled: %ergebnis.allRules%
 		noIsset:
-			enabled: true
+			enabled: %ergebnis.allRules%
 		noNullableReturnTypeDeclaration:
-			enabled: true
+			enabled: %ergebnis.allRules%
 		noParameterPassedByReference:
-			enabled: true
+			enabled: %ergebnis.allRules%
 		noParameterWithContainerTypeDeclaration:
-			enabled: true
+			enabled: %ergebnis.allRules%
 			interfacesImplementedByContainers:
 				- Psr\Container\ContainerInterface
 			methodsAllowedToUseContainerTypeDeclarations: []
 		noParameterWithNullableTypeDeclaration:
-			enabled: true
+			enabled: %ergebnis.allRules%
 		noParameterWithNullDefaultValue:
-			enabled: true
+			enabled: %ergebnis.allRules%
 		noReturnByReference:
-			enabled: true
+			enabled: %ergebnis.allRules%
 		noSwitch:
-			enabled: true
+			enabled: %ergebnis.allRules%
 		privateInFinalClass:
-			enabled: true
+			enabled: %ergebnis.allRules%
 		testCaseWithSuffix:
-			enabled: true
+			enabled: %ergebnis.allRules%
 
 parametersSchema:
 	ergebnis: structure([
+		allRules: bool()
 		declareStrictTypes: structure([
 			enabled: bool(),
 		])


### PR DESCRIPTION
This pull request

- [x] extracts an `allRules` parameter to allow disabling and enabling all rules

Fixes #652.