### PR TITLE
Enhancement: Implement `NoAssignByReferenceRule`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`2.7.0...main`][2.7.0...main].
 ### Added
 
 - Added `allRules` parameter to allow disabling and enabling all rules  ([#913]), by [@localheinz]
+- Added `Expressions\NoAssignByReferenceRule`, which reports an error when a variable is assigned by reference ([#914]), by [@localheinz]
 
 ## [`2.7.0`][2.7.0]
 
@@ -617,6 +618,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [#911]: https://github.com/ergebnis/phpstan-rules/pull/911
 [#912]: https://github.com/ergebnis/phpstan-rules/pull/912
 [#913]: https://github.com/ergebnis/phpstan-rules/pull/913
+[#914]: https://github.com/ergebnis/phpstan-rules/pull/914
 
 [@cosmastech]: https://github.com/cosmastech
 [@enumag]: https://github.com/enumag

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 - [`Ergebnis\PHPStan\Rules\Closures\NoParameterPassedByReferenceRule`](https://github.com/ergebnis/phpstan-rules#closuresnoparameterpassedbyreferencerule)
 - [`Ergebnis\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule`](https://github.com/ergebnis/phpstan-rules#closuresnoparameterwithnullabletypedeclarationrule)
 - [`Ergebnis\PHPStan\Rules\Closures\NoParameterWithNullDefaultValueRule`](https://github.com/ergebnis/phpstan-rules#closuresnoparameterwithnulldefaultvaluerule)
+- [`Ergebnis\PHPStan\Rules\Expressions\NoAssignByReferenceRule`](https://github.com/ergebnis/phpstan-rules#expressionsnoassignbyreferencerule)
 - [`Ergebnis\PHPStan\Rules\Expressions\NoCompactRule`](https://github.com/ergebnis/phpstan-rules#expressionsnocompactrule)
 - [`Ergebnis\PHPStan\Rules\Expressions\NoErrorSuppressionRule`](https://github.com/ergebnis/phpstan-rules#expressionsnoerrorsuppressionrule)
 - [`Ergebnis\PHPStan\Rules\Expressions\NoEvalRule`](https://github.com/ergebnis/phpstan-rules#expressionsnoevalrule)
@@ -234,6 +235,21 @@ parameters:
 ```
 
 ### Expressions
+
+#### `Expressions\NoAssignByReferenceRule`
+
+This rule reports an error when [a variable is assigned by reference](https://www.php.net/manual/en/language.references.whatdo.php#language.references.whatdo.assign).
+
+##### Disabling the rule
+
+You can set the `enabled` parameter to `false` to disable this rule.
+
+```neon
+parameters:
+	ergebnis:
+		noAssignByReference:
+			enabled: false
+```
 
 #### `Expressions\NoCompactRule`
 

--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -7,6 +7,7 @@
     "null",
     "PhpParser\\Comment\\Doc",
     "PhpParser\\Node",
+    "PhpParser\\Node\\Expr\\AssignRef",
     "PhpParser\\Node\\Expr\\Closure",
     "PhpParser\\Node\\Expr\\ConstFetch",
     "PhpParser\\Node\\Expr\\ErrorSuppress",

--- a/rules.neon
+++ b/rules.neon
@@ -11,6 +11,8 @@ conditionalTags:
 		phpstan.rules.rule: %ergebnis.noParameterPassedByReference.enabled%
 	Ergebnis\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule:
 		phpstan.rules.rule: %ergebnis.noParameterWithNullableTypeDeclaration.enabled%
+	Ergebnis\PHPStan\Rules\Expressions\NoAssignByReferenceRule:
+		phpstan.rules.rule: %ergebnis.noAssignByReference.enabled%
 	Ergebnis\PHPStan\Rules\Expressions\NoCompactRule:
 		phpstan.rules.rule: %ergebnis.noCompact.enabled%
 	Ergebnis\PHPStan\Rules\Expressions\NoErrorSuppressionRule:
@@ -63,6 +65,8 @@ parameters:
 			enabled: %ergebnis.allRules%
 		finalInAbstractClass:
 			enabled: %ergebnis.allRules%
+		noAssignByReference:
+			enabled: %ergebnis.allRules%
 		noCompact:
 			enabled: %ergebnis.allRules%
 		noConstructorParameterWithDefaultValue:
@@ -110,6 +114,9 @@ parametersSchema:
 			enabled: bool(),
 		])
 		finalInAbstractClass: structure([
+			enabled: bool(),
+		])
+		noAssignByReference: structure([
 			enabled: bool(),
 		])
 		noCompact: structure([
@@ -188,6 +195,9 @@ services:
 
 	-
 		class: Ergebnis\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule
+
+	-
+		class: Ergebnis\PHPStan\Rules\Expressions\NoAssignByReferenceRule
 
 	-
 		class: Ergebnis\PHPStan\Rules\Expressions\NoCompactRule

--- a/src/ErrorIdentifier.php
+++ b/src/ErrorIdentifier.php
@@ -50,6 +50,11 @@ final class ErrorIdentifier
         return new self('noConstructorParameterWithDefaultValue');
     }
 
+    public static function noAssignByReference(): self
+    {
+        return new self('noAssignByReference');
+    }
+
     public static function noErrorSuppression(): self
     {
         return new self('noErrorSuppression');

--- a/src/Expressions/NoAssignByReferenceRule.php
+++ b/src/Expressions/NoAssignByReferenceRule.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2025 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpstan-rules
+ */
+
+namespace Ergebnis\PHPStan\Rules\Expressions;
+
+use Ergebnis\PHPStan\Rules\ErrorIdentifier;
+use PhpParser\Node;
+use PHPStan\Analyser;
+use PHPStan\Rules;
+
+/**
+ * @implements Rules\Rule<Node\Expr\AssignRef>
+ */
+final class NoAssignByReferenceRule implements Rules\Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Expr\AssignRef::class;
+    }
+
+    public function processNode(
+        Node $node,
+        Analyser\Scope $scope
+    ): array {
+        return [
+            Rules\RuleErrorBuilder::message('Assign by reference should not be used.')
+                ->identifier(ErrorIdentifier::noAssignByReference()->toString())
+                ->build(),
+        ];
+    }
+}

--- a/test/Fixture/Expressions/NoAssignByReferenceRule/script.php
+++ b/test/Fixture/Expressions/NoAssignByReferenceRule/script.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Expressions\NoAssignByReferenceRule;
+
+$foo = 'bar';
+
+$bar = $foo;
+
+$baz = &$foo;

--- a/test/Integration/Expressions/NoAssignByReferenceRuleTest.php
+++ b/test/Integration/Expressions/NoAssignByReferenceRuleTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2025 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpstan-rules
+ */
+
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Expressions;
+
+use Ergebnis\PHPStan\Rules\Expressions;
+use Ergebnis\PHPStan\Rules\Test;
+use PHPStan\Rules;
+use PHPStan\Testing;
+
+/**
+ * @covers \Ergebnis\PHPStan\Rules\Expressions\NoAssignByReferenceRule
+ *
+ * @uses \Ergebnis\PHPStan\Rules\ErrorIdentifier
+ *
+ * @extends Testing\RuleTestCase<Expressions\NoAssignByReferenceRule>
+ */
+final class NoAssignByReferenceRuleTest extends Testing\RuleTestCase
+{
+    use Test\Util\Helper;
+
+    public function testNoAssignByReferenceRule(): void
+    {
+        $this->analyse(
+            self::phpFilesIn(__DIR__ . '/../../Fixture/Expressions/NoAssignByReferenceRule'),
+            [
+                [
+                    'Assign by reference should not be used.',
+                    11,
+                ],
+            ],
+        );
+    }
+
+    protected function getRule(): Rules\Rule
+    {
+        return new Expressions\NoAssignByReferenceRule();
+    }
+}

--- a/test/Unit/ErrorIdentifierTest.php
+++ b/test/Unit/ErrorIdentifierTest.php
@@ -42,6 +42,13 @@ final class ErrorIdentifierTest extends Framework\TestCase
         self::assertSame('ergebnis.final', $errorIdentifier->toString());
     }
 
+    public function testNoAssignByReferenceReturnsErrorIdentifier(): void
+    {
+        $errorIdentifier = ErrorIdentifier::noAssignByReference();
+
+        self::assertSame('ergebnis.noAssignByReference', $errorIdentifier->toString());
+    }
+
     public function testNoCompactReturnsErrorIdentifier(): void
     {
         $errorIdentifier = ErrorIdentifier::noCompact();


### PR DESCRIPTION
This pull request

- [x] implements a `NoAssignByReferenceRule`, which reports an error when a variable is assigned by reference