### PR TITLE
Enhancement: Implement `InvokeParentHookMethodRule`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.9.0...main`][2.9.0...main].
 
+### Added
+
+- Added `Methods\InvokeParentHookMethodRule`, which reports an error when a hook method that overrides a hook method in a parent class does not invoke the overridden hook method in the expected order ([#939]), by [@localheinz]
+
 ## [`2.9.0`][2.9.0]
 
 For a full diff see [`2.8.0...2.9.0`][2.8.0...2.9.0].
@@ -640,6 +644,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [#913]: https://github.com/ergebnis/phpstan-rules/pull/913
 [#914]: https://github.com/ergebnis/phpstan-rules/pull/914
 [#938]: https://github.com/ergebnis/phpstan-rules/pull/938
+[#939]: https://github.com/ergebnis/phpstan-rules/pull/939
 
 [@cosmastech]: https://github.com/cosmastech
 [@enumag]: https://github.com/enumag

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 - [`Ergebnis\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule`](https://github.com/ergebnis/phpstan-rules#functionsnoparameterwithnulldefaultvaluerule)
 - [`Ergebnis\PHPStan\Rules\Functions\NoReturnByReferenceRule`](https://github.com/ergebnis/phpstan-rules#functionsnoreturnbyreferencerule)
 - [`Ergebnis\PHPStan\Rules\Methods\FinalInAbstractClassRule`](https://github.com/ergebnis/phpstan-rules#methodsfinalinabstractclassrule)
+- [`Ergebnis\PHPStan\Rules\Methods\InvokeParentHookMethodRule`](https://github.com/ergebnis/phpstan-rules#methodsinvokeparenthookmethodrule)
 - [`Ergebnis\PHPStan\Rules\Methods\NoConstructorParameterWithDefaultValueRule`](https://github.com/ergebnis/phpstan-rules#methodsnoconstructorparameterwithdefaultvaluerule)
 - [`Ergebnis\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule`](https://github.com/ergebnis/phpstan-rules#methodsnonullablereturntypedeclarationrule)
 - [`Ergebnis\PHPStan\Rules\Methods\NoParameterPassedByReferenceRule`](https://github.com/ergebnis/phpstan-rules#methodsnoparameterpassedbyreferencerule)
@@ -445,6 +446,63 @@ parameters:
 		finalInAbstractClass:
 			enabled: false
 ```
+
+#### `Methods\InvokeParentHookMethodRule`
+
+This rule reports an error when a hook method that overrides a hook method in a parent class does not invoke the overridden hook method in the expected order.
+
+##### Defaults
+
+By default, this rule requires the following hook methods to be invoked before doing something in the overriding method:
+
+- [`Codeception\PHPUnit\TestCase::_setUp()`](https://github.com/Codeception/phpunit-wrapper/blob/9.0.0/src/TestCase.php#L11-L13)
+- [`Codeception\PHPUnit\TestCase::_setUpBeforeClass()`](https://github.com/Codeception/phpunit-wrapper/blob/9.0.0/src/TestCase.php#L25-L27)
+- [`Codeception\Test\Unit::_before()`](https://github.com/Codeception/Codeception/blob/4.2.2/src/Codeception/Test/Unit.php#L63-L65)
+- [`Codeception\Test\Unit::_setUp()`](https://github.com/Codeception/Codeception/blob/4.2.2/src/Codeception/Test/Unit.php#L34-L58)
+- [`PHPUnit\Framework\TestCase::assertPreConditions()`](https://github.com/sebastianbergmann/phpunit/blob/6.0.0/src/Framework/TestCase.php#L2073-L2075)
+- [`PHPUnit\Framework\TestCase::setUp()`](https://github.com/sebastianbergmann/phpunit/blob/6.0.0/src/Framework/TestCase.php#L2063-L2065)
+- [`PHPUnit\Framework\TestCase::setUpBeforeClass()`](https://github.com/sebastianbergmann/phpunit/blob/6.0.0/src/Framework/TestCase.php#L2055-L2057)
+
+By default, this rule requires the following hook methods to be invoked after doing something in the overriding method:
+
+- [`Codeception\PHPUnit\TestCase::_tearDown()`](https://github.com/Codeception/phpunit-wrapper/blob/9.0.0/src/TestCase.php#L18-L20)
+- [`Codeception\PHPUnit\TestCase::_tearDownAfterClass()`](https://github.com/Codeception/phpunit-wrapper/blob/9.0.0/src/TestCase.php#L32-L34)
+- [`Codeception\Test\Unit::_after()`](https://github.com/Codeception/Codeception/blob/4.2.2/src/Codeception/Test/Unit.php#L75-L77)
+- [`Codeception\Test\Unit::_tearDown()`](https://github.com/Codeception/Codeception/blob/4.2.2/src/Codeception/Test/Unit.php#L67-L70)
+- [`PHPUnit\Framework\TestCase::assertPostConditions()`](https://github.com/sebastianbergmann/phpunit/blob/6.0.0/src/Framework/TestCase.php#L2083-L2085)
+- [`PHPUnit\Framework\TestCase::tearDown()`](https://github.com/sebastianbergmann/phpunit/blob/6.0.0/src/Framework/TestCase.php#L2091-L2093)
+- [`PHPUnit\Framework\TestCase::tearDownAfterClass()`](https://github.com/sebastianbergmann/phpunit/blob/6.0.0/src/Framework/TestCase.php#L2098-L2100)
+
+##### Disabling the rule
+
+You can set the `enabled` parameter to `false` to disable this rule.
+
+```neon
+parameters:
+	ergebnis:
+		invokeParentHookMethod:
+			enabled: false
+```
+
+##### Configuring methods to invoke the parent method in the right order:
+
+You can set the `hookMethods` parameter to a list of hook methods:
+
+```neon
+parameters:
+	ergebnis:
+		invokeParentHookMethod:
+			hookMethods:
+				- className: "Example\Test\Functional\AbstractCest"
+					methodName: "_before"
+					hasContent: "yes"
+					invocation: "first"
+```
+
+- `className`: name of the class that declares the hook method
+- `methodName`: name of the hook method
+- `hasContent`: one of `"yes"`, `"no"`, `"maybe"`
+- `invocation`: one of `"any"` (needs to be invoked), `"first"` (needs to be invoked before all other statements in the overriding hook method, `"last"` (needs to be invoked after all other statements in the overriding hook method)
 
 #### `Methods\NoConstructorParameterWithDefaultValueRule`
 

--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -2,6 +2,8 @@
   "symbol-whitelist": [
     "array",
     "bool",
+    "Codeception\\PHPUnit\\TestCase",
+    "Codeception\\Test\\Unit",
     "Doctrine\\ORM\\Mapping\\Embeddable",
     "Doctrine\\ORM\\Mapping\\Entity",
     "false",
@@ -30,6 +32,7 @@
     "PhpParser\\Node\\Stmt\\Class_",
     "PhpParser\\Node\\Stmt\\ClassMethod",
     "PhpParser\\Node\\Stmt\\Declare_",
+    "PhpParser\\Node\\Stmt\\Expression",
     "PhpParser\\Node\\Stmt\\Function_",
     "PhpParser\\Node\\Stmt\\InlineHTML",
     "PhpParser\\Node\\Stmt\\Switch_",

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,13 @@
     "phpstan/phpstan": "^2.1.8"
   },
   "require-dev": {
+    "codeception/codeception": "^4.0.0 || ^5.0.0",
     "doctrine/orm": "^2.20.0 || ^3.3.0",
     "ergebnis/composer-normalize": "^2.47.0",
     "ergebnis/license": "^2.6.0",
     "ergebnis/php-cs-fixer-config": "^6.46.0",
     "ergebnis/phpunit-slow-test-detector": "^2.19.1",
+    "fakerphp/faker": "^1.24.1",
     "nette/di": "^3.1.10",
     "phpstan/extension-installer": "^1.4.3",
     "phpstan/phpstan-deprecation-rules": "^2.0.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e06002510aba9a337c00908b9eac2d8c",
+    "content-hash": "c4402cd984037fa0b3b8afba53638df3",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -66,6 +66,69 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "behat/gherkin",
+            "version": "v4.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Behat/Gherkin.git",
+                "reference": "cbb83c4c435dd8d05a161f2a5ae322e61b2f4db6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Behat/Gherkin/zipball/cbb83c4c435dd8d05a161f2a5ae322e61b2f4db6",
+                "reference": "cbb83c4c435dd8d05a161f2a5ae322e61b2f4db6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.2|~8.0"
+            },
+            "require-dev": {
+                "cucumber/cucumber": "dev-gherkin-24.1.0",
+                "phpunit/phpunit": "~8|~9",
+                "symfony/yaml": "~3|~4|~5|~6|~7"
+            },
+            "suggest": {
+                "symfony/yaml": "If you want to parse features, represented in YAML files"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Behat\\Gherkin": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                }
+            ],
+            "description": "Gherkin DSL parser for PHP",
+            "homepage": "http://behat.org/",
+            "keywords": [
+                "BDD",
+                "Behat",
+                "Cucumber",
+                "DSL",
+                "gherkin",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/Behat/Gherkin/issues",
+                "source": "https://github.com/Behat/Gherkin/tree/v4.10.0"
+            },
+            "time": "2024-10-19T14:46:06+00:00"
+        },
         {
             "name": "clue/ndjson-react",
             "version": "v1.3.0",
@@ -129,6 +192,246 @@
                 }
             ],
             "time": "2022-12-23T10:58:28+00:00"
+        },
+        {
+            "name": "codeception/codeception",
+            "version": "4.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Codeception/Codeception.git",
+                "reference": "b88014f3348c93f3df99dc6d0967b0dbfa804474"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Codeception/Codeception/zipball/b88014f3348c93f3df99dc6d0967b0dbfa804474",
+                "reference": "b88014f3348c93f3df99dc6d0967b0dbfa804474",
+                "shasum": ""
+            },
+            "require": {
+                "behat/gherkin": "^4.4.0",
+                "codeception/lib-asserts": "^1.0 | 2.0.*@dev",
+                "codeception/phpunit-wrapper": ">6.0.15 <6.1.0 | ^6.6.1 | ^7.7.1 | ^8.1.1 | ^9.0",
+                "codeception/stub": "^2.0 | ^3.0 | ^4.0",
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "guzzlehttp/psr7": "^1.4 | ^2.0",
+                "php": ">=5.6.0 <9.0",
+                "symfony/console": ">=2.7 <6.0",
+                "symfony/css-selector": ">=2.7 <6.0",
+                "symfony/event-dispatcher": ">=2.7 <6.0",
+                "symfony/finder": ">=2.7 <6.0",
+                "symfony/yaml": ">=2.7 <6.0"
+            },
+            "require-dev": {
+                "codeception/module-asserts": "^1.0 | 2.0.*@dev",
+                "codeception/module-cli": "^1.0 | 2.0.*@dev",
+                "codeception/module-db": "^1.0 | 2.0.*@dev",
+                "codeception/module-filesystem": "^1.0 | 2.0.*@dev",
+                "codeception/module-phpbrowser": "^1.0 | 2.0.*@dev",
+                "codeception/specify": "~0.3",
+                "codeception/util-universalframework": "*@dev",
+                "monolog/monolog": "~1.8",
+                "squizlabs/php_codesniffer": "~2.0",
+                "symfony/process": ">=2.7 <6.0",
+                "vlucas/phpdotenv": "^2.0 | ^3.0 | ^4.0 | ^5.0"
+            },
+            "suggest": {
+                "codeception/specify": "BDD-style code blocks",
+                "codeception/verify": "BDD-style assertions",
+                "hoa/console": "For interactive console functionality",
+                "stecman/symfony-console-completion": "For BASH autocompletion",
+                "symfony/phpunit-bridge": "For phpunit-bridge support"
+            },
+            "bin": [
+                "codecept"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": []
+            },
+            "autoload": {
+                "files": [
+                    "functions.php"
+                ],
+                "psr-4": {
+                    "Codeception\\": "src/Codeception",
+                    "Codeception\\Extension\\": "ext"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Bodnarchuk",
+                    "email": "davert@mail.ua",
+                    "homepage": "https://codegyre.com"
+                }
+            ],
+            "description": "BDD-style testing framework",
+            "homepage": "https://codeception.com/",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "acceptance testing",
+                "functional testing",
+                "unit testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Codeception/Codeception/issues",
+                "source": "https://github.com/Codeception/Codeception/tree/4.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/codeception",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2022-08-13T13:28:25+00:00"
+        },
+        {
+            "name": "codeception/lib-asserts",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Codeception/lib-asserts.git",
+                "reference": "78c55044611437988b54e1daecf13f247a742bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Codeception/lib-asserts/zipball/78c55044611437988b54e1daecf13f247a742bf8",
+                "reference": "78c55044611437988b54e1daecf13f247a742bf8",
+                "shasum": ""
+            },
+            "require": {
+                "codeception/phpunit-wrapper": "^7.7.1 | ^8.0.3 | ^9.0",
+                "ext-dom": "*",
+                "php": "^7.4 | ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Bodnarchuk",
+                    "email": "davert@mail.ua",
+                    "homepage": "http://codegyre.com"
+                },
+                {
+                    "name": "Gintautas Miselis"
+                },
+                {
+                    "name": "Gustavo Nieves",
+                    "homepage": "https://medium.com/@ganieves"
+                }
+            ],
+            "description": "Assertion methods used by Codeception core and Asserts module",
+            "homepage": "https://codeception.com/",
+            "keywords": [
+                "codeception"
+            ],
+            "support": {
+                "issues": "https://github.com/Codeception/lib-asserts/issues",
+                "source": "https://github.com/Codeception/lib-asserts/tree/2.0.1"
+            },
+            "time": "2022-09-27T06:17:39+00:00"
+        },
+        {
+            "name": "codeception/phpunit-wrapper",
+            "version": "9.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Codeception/phpunit-wrapper.git",
+                "reference": "7439a53ae367986e9c22b2ac00f9d7376bb2f8cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Codeception/phpunit-wrapper/zipball/7439a53ae367986e9c22b2ac00f9d7376bb2f8cf",
+                "reference": "7439a53ae367986e9c22b2ac00f9d7376bb2f8cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "phpunit/phpunit": "^9.0"
+            },
+            "require-dev": {
+                "codeception/specify": "*",
+                "consolidation/robo": "^3.0.0-alpha3",
+                "vlucas/phpdotenv": "^3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Codeception\\PHPUnit\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Davert",
+                    "email": "davert.php@resend.cc"
+                },
+                {
+                    "name": "Naktibalda"
+                }
+            ],
+            "description": "PHPUnit classes used by Codeception",
+            "support": {
+                "issues": "https://github.com/Codeception/phpunit-wrapper/issues",
+                "source": "https://github.com/Codeception/phpunit-wrapper/tree/9.0.9"
+            },
+            "abandoned": true,
+            "time": "2022-05-23T06:24:11+00:00"
+        },
+        {
+            "name": "codeception/stub",
+            "version": "4.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Codeception/Stub.git",
+                "reference": "18a148dacd293fc7b044042f5aa63a82b08bff5d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Codeception/Stub/zipball/18a148dacd293fc7b044042f5aa63a82b08bff5d",
+                "reference": "18a148dacd293fc7b044042f5aa63a82b08bff5d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 | ^8.0",
+                "phpunit/phpunit": "^8.4 | ^9.0 | ^10.0 | 10.0.x-dev"
+            },
+            "require-dev": {
+                "consolidation/robo": "^3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Codeception\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Flexible Stub wrapper for PHPUnit's Mock Builder",
+            "support": {
+                "issues": "https://github.com/Codeception/Stub/issues",
+                "source": "https://github.com/Codeception/Stub/tree/4.0.2"
+            },
+            "time": "2022-01-31T19:25:15+00:00"
         },
         {
             "name": "composer/pcre",
@@ -2080,6 +2383,69 @@
             "time": "2023-08-08T05:53:35+00:00"
         },
         {
+            "name": "fakerphp/faker",
+            "version": "v1.24.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FakerPHP/Faker.git",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "psr/container": "^1.0 || ^2.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "conflict": {
+                "fzaninotto/faker": "*"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "doctrine/persistence": "^1.3 || ^2.0",
+                "ext-intl": "*",
+                "phpunit/phpunit": "^9.5.26",
+                "symfony/phpunit-bridge": "^5.4.16"
+            },
+            "suggest": {
+                "doctrine/orm": "Required to use Faker\\ORM\\Doctrine",
+                "ext-curl": "Required by Faker\\Provider\\Image to download images.",
+                "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
+                "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
+                "ext-mbstring": "Required for multibyte Unicode string functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "support": {
+                "issues": "https://github.com/FakerPHP/Faker/issues",
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.24.1"
+            },
+            "time": "2024-11-21T13:46:39+00:00"
+        },
+        {
             "name": "fidry/cpu-core-counter",
             "version": "1.2.0",
             "source": {
@@ -2243,6 +2609,122 @@
                 }
             ],
             "time": "2025-03-31T18:40:42+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "2.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/c2270caaabe631b3b44c85f99e5a04bbb8060d16",
+                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
+                "ralouphie/getallheaders": "^3.0"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "http-interop/http-factory-tests": "0.9.0",
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/2.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-03-27T12:30:47+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -3998,6 +4480,114 @@
             "time": "2019-01-08T18:20:26+00:00"
         },
         {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "1.1.4",
             "source": {
@@ -4046,6 +4636,50 @@
                 "source": "https://github.com/php-fig/log/tree/1.1.4"
             },
             "time": "2021-05-03T11:20:27+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
         },
         {
             "name": "react/cache",
@@ -5636,6 +6270,72 @@
             "time": "2024-11-06T11:30:55+00:00"
         },
         {
+            "name": "symfony/css-selector",
+            "version": "v5.4.45",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/css-selector.git",
+                "reference": "4f7f3c35fba88146b56d0025d20ace3f3901f097"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/4f7f3c35fba88146b56d0025d20ace3f3901f097",
+                "reference": "4f7f3c35fba88146b56d0025d20ace3f3901f097",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\CssSelector\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Jean-François Simon",
+                    "email": "jeanfrancois.simon@sensiolabs.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Converts CSS selectors to XPath expressions",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/css-selector/tree/v5.4.45"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:11:13+00:00"
+        },
+        {
             "name": "symfony/deprecation-contracts",
             "version": "v2.5.4",
             "source": {
@@ -6953,6 +7653,81 @@
             "time": "2024-11-10T20:33:58+00:00"
         },
         {
+            "name": "symfony/yaml",
+            "version": "v5.4.45",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "a454d47278cc16a5db371fe73ae66a78a633371e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a454d47278cc16a5db371fe73ae66a78a633371e",
+                "reference": "a454d47278cc16a5db371fe73ae66a78a633371e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<5.3"
+            },
+            "require-dev": {
+                "symfony/console": "^5.3|^6.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v5.4.45"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:11:13+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.2.3",
             "source": {
@@ -7005,16 +7780,16 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
         "ext-mbstring": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4.33"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,6 +7,12 @@ parameters:
 			path: src/CallLikes/NoNamedArgumentRule.php
 
 		-
+			message: '#^Method Ergebnis\\PHPStan\\Rules\\ClassName\:\:toString\(\) should return class\-string but returns string\.$#'
+			identifier: return.type
+			count: 1
+			path: src/ClassName.php
+
+		-
 			message: '#^Language construct isset\(\) should not be used\.$#'
 			identifier: ergebnis.noIsset
 			count: 1
@@ -29,6 +35,48 @@ parameters:
 			identifier: ergebnis.noIsset
 			count: 1
 			path: src/Functions/NoNullableReturnTypeDeclarationRule.php
+
+		-
+			message: '#^Method Ergebnis\\PHPStan\\Rules\\Invocation\:\:toString\(\) should return non\-empty\-string but returns string\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Invocation.php
+
+		-
+			message: '#^Method Ergebnis\\PHPStan\\Rules\\MethodName\:\:toString\(\) should return non\-empty\-string but returns string\.$#'
+			identifier: return.type
+			count: 1
+			path: src/MethodName.php
+
+		-
+			message: '#^Constructor in Ergebnis\\PHPStan\\Rules\\Methods\\InvokeParentHookMethodRule has parameter \$hookMethods with default value\.$#'
+			identifier: ergebnis.noConstructorParameterWithDefaultValue
+			count: 1
+			path: src/Methods/InvokeParentHookMethodRule.php
+
+		-
+			message: '#^Method Ergebnis\\PHPStan\\Rules\\Methods\\InvokeParentHookMethodRule\:\:findMatchingHookMethod\(\) has a nullable return type declaration\.$#'
+			identifier: ergebnis.noNullableReturnTypeDeclaration
+			count: 1
+			path: src/Methods/InvokeParentHookMethodRule.php
+
+		-
+			message: '#^Method Ergebnis\\PHPStan\\Rules\\Methods\\InvokeParentHookMethodRule\:\:findParentHookMethodInvocation\(\) has a nullable return type declaration\.$#'
+			identifier: ergebnis.noNullableReturnTypeDeclaration
+			count: 1
+			path: src/Methods/InvokeParentHookMethodRule.php
+
+		-
+			message: '#^Parameter \#1 \$value of static method Ergebnis\\PHPStan\\Rules\\ClassName\:\:fromString\(\) expects class\-string, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Methods/InvokeParentHookMethodRule.php
+
+		-
+			message: '#^Parameter \#1 \$value of static method Ergebnis\\PHPStan\\Rules\\MethodName\:\:fromString\(\) expects non\-empty\-string, string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Methods/InvokeParentHookMethodRule.php
 
 		-
 			message: '#^Method Ergebnis\\PHPStan\\Rules\\Methods\\NoParameterWithContainerTypeDeclarationRule\:\:processNode\(\) should return list\<PHPStan\\Rules\\IdentifierRuleError\> but returns list\.$#'
@@ -59,4 +107,22 @@ parameters:
 			identifier: class.notFound
 			count: 1
 			path: src/Methods/PrivateInFinalClassRule.php
+
+		-
+			message: '#^Parameter \#2 \$hookMethods of class Ergebnis\\PHPStan\\Rules\\Methods\\InvokeParentHookMethodRule constructor expects array\<class\-string, array\<string, string\>\>, array\<int, array\<string, string\>\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: test/Integration/Methods/InvokeParentHookMethodRuleWithCustomConfigurationTest.php
+
+		-
+			message: '#^Parameter \#3 \$invocation of static method Ergebnis\\PHPStan\\Rules\\HookMethod\:\:create\(\) expects Ergebnis\\PHPStan\\Rules\\Invocation, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: test/Unit/HookMethodTest.php
+
+		-
+			message: '#^Parameter \#4 \$hasContent of static method Ergebnis\\PHPStan\\Rules\\HookMethod\:\:create\(\) expects Ergebnis\\PHPStan\\Rules\\HasContent, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: test/Unit/HookMethodTest.php
 

--- a/rules.neon
+++ b/rules.neon
@@ -37,6 +37,8 @@ conditionalTags:
 		phpstan.rules.rule: %ergebnis.noReturnByReference.enabled%
 	Ergebnis\PHPStan\Rules\Methods\FinalInAbstractClassRule:
 		phpstan.rules.rule: %ergebnis.finalInAbstractClass.enabled%
+	Ergebnis\PHPStan\Rules\Methods\InvokeParentHookMethodRule:
+		phpstan.rules.rule: %ergebnis.invokeParentHookMethod.enabled%
 	Ergebnis\PHPStan\Rules\Methods\NoConstructorParameterWithDefaultValueRule:
 		phpstan.rules.rule: %ergebnis.noConstructorParameterWithDefaultValue.enabled%
 	Ergebnis\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule:
@@ -67,6 +69,9 @@ parameters:
 			enabled: %ergebnis.allRules%
 		finalInAbstractClass:
 			enabled: %ergebnis.allRules%
+		invokeParentHookMethod:
+			enabled: %ergebnis.allRules%
+			hookMethods: []
 		noAssignByReference:
 			enabled: %ergebnis.allRules%
 		noCompact:
@@ -119,6 +124,15 @@ parametersSchema:
 		])
 		finalInAbstractClass: structure([
 			enabled: bool(),
+		])
+		invokeParentHookMethod: structure([
+			enabled: bool(),
+			hookMethods: listOf(structure([
+				className: string(),
+				hasContent: anyOf("no", "yes"),
+				invocation: anyOf("after", "any", "before"),
+				methodName: string(),
+			]))
 		])
 		noAssignByReference: structure([
 			enabled: bool(),
@@ -241,6 +255,11 @@ services:
 
 	-
 		class: Ergebnis\PHPStan\Rules\Methods\FinalInAbstractClassRule
+
+	-
+		class: Ergebnis\PHPStan\Rules\Methods\InvokeParentHookMethodRule
+		arguments:
+			hookMethods: %ergebnis.invokeParentHookMethod.hookMethods%
 
 	-
 		class: Ergebnis\PHPStan\Rules\Methods\NoConstructorParameterWithDefaultValueRule

--- a/src/ClassName.php
+++ b/src/ClassName.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2025 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpstan-rules
+ */
+
+namespace Ergebnis\PHPStan\Rules;
+
+/**
+ * @internal
+ */
+final class ClassName
+{
+    private string $value;
+
+    /**
+     * @param class-string $value
+     */
+    private function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @param class-string $value
+     */
+    public static function fromString(string $value): self
+    {
+        return new self($value);
+    }
+
+    /**
+     * @return class-string
+     */
+    public function toString(): string
+    {
+        return $this->value;
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->value === $other->value;
+    }
+}

--- a/src/ErrorIdentifier.php
+++ b/src/ErrorIdentifier.php
@@ -40,6 +40,11 @@ final class ErrorIdentifier
         return new self('finalInAbstractClass');
     }
 
+    public static function invokeParentMethod(): self
+    {
+        return new self('invokeParentMethod');
+    }
+
     public static function noCompact(): self
     {
         return new self('noCompact');

--- a/src/HasContent.php
+++ b/src/HasContent.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2025 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpstan-rules
+ */
+
+namespace Ergebnis\PHPStan\Rules;
+
+/**
+ * @internal
+ */
+final class HasContent
+{
+    private string $value;
+
+    private function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public static function fromString(string $value): self
+    {
+        $values = [
+            'maybe',
+            'no',
+            'yes',
+        ];
+
+        if (!\in_array($value, $values, true)) {
+            throw new \InvalidArgumentException(\sprintf(
+                'Value needs to be one of "%s", got "%s" instead.',
+                \implode('", "', $values),
+                $value,
+            ));
+        }
+
+        return new self($value);
+    }
+
+    public static function maybe(): self
+    {
+        return new self('maybe');
+    }
+
+    public static function no(): self
+    {
+        return new self('no');
+    }
+
+    public static function yes(): self
+    {
+        return new self('yes');
+    }
+
+    public function toString(): string
+    {
+        return $this->value;
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->value === $other->value;
+    }
+}

--- a/src/HookMethod.php
+++ b/src/HookMethod.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2025 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpstan-rules
+ */
+
+namespace Ergebnis\PHPStan\Rules;
+
+/**
+ * @internal
+ */
+final class HookMethod
+{
+    private ClassName $className;
+    private MethodName $methodName;
+    private Invocation $invocation;
+    private HasContent $hasContent;
+
+    private function __construct(
+        ClassName $className,
+        MethodName $methodName,
+        Invocation $invocation,
+        HasContent $hasContent
+    ) {
+        $this->className = $className;
+        $this->methodName = $methodName;
+        $this->invocation = $invocation;
+        $this->hasContent = $hasContent;
+    }
+
+    public static function create(
+        ClassName $className,
+        MethodName $methodName,
+        Invocation $invocation,
+        HasContent $hasContent
+    ): self {
+        return new self(
+            $className,
+            $methodName,
+            $invocation,
+            $hasContent,
+        );
+    }
+
+    public function className(): ClassName
+    {
+        return $this->className;
+    }
+
+    public function methodName(): MethodName
+    {
+        return $this->methodName;
+    }
+
+    public function invocation(): Invocation
+    {
+        return $this->invocation;
+    }
+
+    public function hasContent(): HasContent
+    {
+        return $this->hasContent;
+    }
+}

--- a/src/Invocation.php
+++ b/src/Invocation.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2025 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpstan-rules
+ */
+
+namespace Ergebnis\PHPStan\Rules;
+
+/**
+ * @internal
+ */
+final class Invocation
+{
+    private string $value;
+
+    /**
+     * @param non-empty-string $value
+     */
+    private function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public static function fromString(string $value): self
+    {
+        $values = [
+            'any',
+            'first',
+            'last',
+            'never',
+        ];
+
+        if (!\in_array($value, $values, true)) {
+            throw new \InvalidArgumentException(\sprintf(
+                'Value needs to be one of "%s", got "%s" instead.',
+                \implode('", "', $values),
+                $value,
+            ));
+        }
+
+        return new self($value);
+    }
+
+    public static function any(): self
+    {
+        return new self('any');
+    }
+
+    public static function first(): self
+    {
+        return new self('first');
+    }
+
+    public static function last(): self
+    {
+        return new self('last');
+    }
+
+    public static function never(): self
+    {
+        return new self('never');
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function toString(): string
+    {
+        return $this->value;
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->value === $other->value;
+    }
+}

--- a/src/MethodName.php
+++ b/src/MethodName.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2025 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpstan-rules
+ */
+
+namespace Ergebnis\PHPStan\Rules;
+
+/**
+ * @internal
+ */
+final class MethodName
+{
+    private string $value;
+
+    /**
+     * @param non-empty-string $value
+     */
+    private function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @param non-empty-string $value
+     */
+    public static function fromString(string $value): self
+    {
+        return new self($value);
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function toString(): string
+    {
+        return $this->value;
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->value === $other->value;
+    }
+}

--- a/src/Methods/InvokeParentHookMethodRule.php
+++ b/src/Methods/InvokeParentHookMethodRule.php
@@ -1,0 +1,428 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2025 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpstan-rules
+ */
+
+namespace Ergebnis\PHPStan\Rules\Methods;
+
+use Codeception\PHPUnit;
+use Codeception\Test;
+use Ergebnis\PHPStan\Rules\ClassName;
+use Ergebnis\PHPStan\Rules\ErrorIdentifier;
+use Ergebnis\PHPStan\Rules\HasContent;
+use Ergebnis\PHPStan\Rules\HookMethod;
+use Ergebnis\PHPStan\Rules\Invocation;
+use Ergebnis\PHPStan\Rules\MethodName;
+use PhpParser\Node;
+use PHPStan\Analyser;
+use PHPStan\Reflection;
+use PHPStan\Rules;
+use PHPStan\ShouldNotHappenException;
+use PHPUnit\Framework;
+
+/**
+ * @implements Rules\Rule<Node\Stmt\ClassMethod>
+ */
+final class InvokeParentHookMethodRule implements Rules\Rule
+{
+    private Reflection\ReflectionProvider $reflectionProvider;
+
+    /**
+     * @var list<HookMethod>
+     */
+    private array $hookMethods;
+
+    /**
+     * @param array<class-string, array<string, string>> $hookMethods
+     */
+    public function __construct(
+        Reflection\ReflectionProvider $reflectionProvider,
+        array $hookMethods = []
+    ) {
+        $this->reflectionProvider = $reflectionProvider;
+        $this->hookMethods = self::sort(
+            $reflectionProvider,
+            ...self::filter(
+                $reflectionProvider,
+                ...\array_merge(
+                    self::defaultHookMethods(),
+                    \array_map(static function (array $hookMethod): HookMethod {
+                        return HookMethod::create(
+                            ClassName::fromString($hookMethod['className']),
+                            MethodName::fromString($hookMethod['methodName']),
+                            Invocation::fromString($hookMethod['invocation']),
+                            HasContent::fromString($hookMethod['hasContent']),
+                        );
+                    }, $hookMethods),
+                ),
+            ),
+        );
+    }
+
+    public function getNodeType(): string
+    {
+        return Node\Stmt\ClassMethod::class;
+    }
+
+    public function processNode(
+        Node $node,
+        Analyser\Scope $scope
+    ): array {
+        $classReflection = $scope->getClassReflection();
+
+        if (null === $classReflection) {
+            return [];
+        }
+
+        $parentClassReflection = $classReflection->getParentClass();
+
+        if (null === $parentClassReflection) {
+            return [];
+        }
+
+        $methodName = $node->name->toString();
+
+        $hookMethod = $this->findMatchingHookMethod(
+            $scope,
+            $parentClassReflection,
+            $classReflection,
+            $methodName,
+        );
+
+        if (!$hookMethod instanceof HookMethod) {
+            return [];
+        }
+
+        $statements = $node->getStmts();
+
+        if (!\is_array($statements)) {
+            throw new ShouldNotHappenException();
+        }
+
+        $parentHookMethodInvocation = self::findParentHookMethodInvocation(
+            \array_values($statements),
+            $hookMethod,
+        );
+
+        if (!$parentHookMethodInvocation instanceof Invocation) {
+            if ($hookMethod->hasContent()->equals(HasContent::no())) {
+                return [];
+            }
+
+            $message = \sprintf(
+                'Method %s::%s() does not invoke parent::%s().',
+                $classReflection->getName(),
+                $methodName,
+                $hookMethod->methodName()->toString(),
+            );
+
+            return [
+                Rules\RuleErrorBuilder::message($message)
+                    ->identifier(ErrorIdentifier::invokeParentMethod()->toString())
+                    ->build(),
+            ];
+        }
+
+        if ($parentHookMethodInvocation->equals($hookMethod->invocation())) {
+            return [];
+        }
+
+        if ($hookMethod->invocation()->equals(Invocation::first())) {
+            $message = \sprintf(
+                'Method %s::%s() does not invoke parent::%s() before all other statements.',
+                $classReflection->getName(),
+                $methodName,
+                $hookMethod->methodName()->toString(),
+            );
+
+            return [
+                Rules\RuleErrorBuilder::message($message)
+                    ->identifier(ErrorIdentifier::invokeParentMethod()->toString())
+                    ->build(),
+            ];
+        }
+
+        if ($hookMethod->invocation()->equals(Invocation::last())) {
+            $message = \sprintf(
+                'Method %s::%s() does not invoke parent::%s() after all other statements.',
+                $classReflection->getName(),
+                $methodName,
+                $hookMethod->methodName()->toString(),
+            );
+
+            return [
+                Rules\RuleErrorBuilder::message($message)
+                    ->identifier(ErrorIdentifier::invokeParentMethod()->toString())
+                    ->build(),
+            ];
+        }
+
+        throw new ShouldNotHappenException();
+    }
+
+    private function findMatchingHookMethod(
+        Analyser\Scope $scope,
+        Reflection\ClassReflection $parentClassReflection,
+        Reflection\ClassReflection $classReflection,
+        string $methodName
+    ): ?HookMethod {
+        foreach ($this->hookMethods as $hookMethod) {
+            if (!$classReflection->isSubclassOfClass($this->reflectionProvider->getClass($hookMethod->className()->toString()))) {
+                continue;
+            }
+
+            if (\mb_strtolower($hookMethod->methodName()->toString()) !== \mb_strtolower($methodName)) {
+                continue;
+            }
+
+            $parentMethodReflection = $parentClassReflection->getMethod(
+                $methodName,
+                $scope,
+            );
+
+            $declaringClassReflection = $parentMethodReflection->getDeclaringClass();
+
+            if (\mb_strtolower($hookMethod->className()->toString()) !== \mb_strtolower($declaringClassReflection->getName())) {
+                return HookMethod::create(
+                    ClassName::fromString($declaringClassReflection->getName()),
+                    MethodName::fromString($methodName),
+                    $hookMethod->invocation(),
+                    HasContent::maybe(),
+                );
+            }
+
+            return $hookMethod;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<Node\Stmt> $statements
+     */
+    private static function findParentHookMethodInvocation(
+        array $statements,
+        HookMethod $hookMethod
+    ): ?Invocation {
+        $statementCount = \count($statements);
+
+        foreach ($statements as $index => $statement) {
+            if (!$statement instanceof Node\Stmt\Expression) {
+                continue;
+            }
+
+            if (!$statement->expr instanceof Node\Expr\StaticCall) {
+                continue;
+            }
+
+            if (!$statement->expr->class instanceof Node\Name) {
+                continue;
+            }
+
+            $className = (string) $statement->expr->class;
+
+            if (\mb_strtolower($className) !== 'parent') {
+                continue;
+            }
+
+            if (!$statement->expr->name instanceof Node\Identifier) {
+                continue;
+            }
+
+            if (\mb_strtolower($statement->expr->name->toString()) === \mb_strtolower($hookMethod->methodName()->toString())) {
+                if (1 === $statementCount) {
+                    return $hookMethod->invocation();
+                }
+
+                if (0 === $index) {
+                    return Invocation::first();
+                }
+
+                if ($statementCount - 1 === $index) {
+                    return Invocation::last();
+                }
+
+                return Invocation::any();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<HookMethod>
+     */
+    private static function filter(
+        Reflection\ReflectionProvider $reflectionProvider,
+        HookMethod ...$hookMethods
+    ): array {
+        return \array_values(\array_filter($hookMethods, static function (HookMethod $hookMethod) use ($reflectionProvider): bool {
+            return $reflectionProvider->hasClass($hookMethod->className()->toString());
+        }));
+    }
+
+    /**
+     * @return list<HookMethod>
+     */
+    private static function sort(
+        Reflection\ReflectionProvider $reflectionProvider,
+        HookMethod ...$hookMethods
+    ): array {
+        \usort($hookMethods, static function (HookMethod $a, HookMethod $b) use ($reflectionProvider): int {
+            if (\mb_strtolower($a->className()->toString()) === \mb_strtolower($b->className()->toString())) {
+                return 0;
+            }
+
+            if ($reflectionProvider->getClass($a->className()->toString())->isSubclassOfClass($reflectionProvider->getClass($b->className()->toString()))) {
+                return -1;
+            }
+
+            return 1;
+        });
+
+        return $hookMethods;
+    }
+
+    /**
+     * @return list<HookMethod>
+     */
+    private static function defaultHookMethods(): array
+    {
+        return [
+            /**
+             * @see https://github.com/sebastianbergmann/phpunit/blob/6.0.0/src/Framework/TestCase.php#L2083-L2085
+             */
+            HookMethod::create(
+                ClassName::fromString(Framework\TestCase::class),
+                MethodName::fromString('assertPostConditions'),
+                Invocation::last(),
+                HasContent::no(),
+            ),
+            /**
+             * @see https://github.com/sebastianbergmann/phpunit/blob/6.0.0/src/Framework/TestCase.php#L2073-L2075
+             */
+            HookMethod::create(
+                ClassName::fromString(Framework\TestCase::class),
+                MethodName::fromString('assertPreConditions'),
+                Invocation::first(),
+                HasContent::no(),
+            ),
+            /**
+             * @see https://github.com/sebastianbergmann/phpunit/blob/6.0.0/src/Framework/TestCase.php#L2063-L2065
+             */
+            HookMethod::create(
+                ClassName::fromString(Framework\TestCase::class),
+                MethodName::fromString('setUp'),
+                Invocation::first(),
+                HasContent::no(),
+            ),
+            /**
+             * @see https://github.com/sebastianbergmann/phpunit/blob/6.0.0/src/Framework/TestCase.php#L2055-L2057
+             */
+            HookMethod::create(
+                ClassName::fromString(Framework\TestCase::class),
+                MethodName::fromString('setUpBeforeClass'),
+                Invocation::first(),
+                HasContent::no(),
+            ),
+            /**
+             * @see https://github.com/sebastianbergmann/phpunit/blob/6.0.0/src/Framework/TestCase.php#L2091-L2093
+             */
+            HookMethod::create(
+                ClassName::fromString(Framework\TestCase::class),
+                MethodName::fromString('tearDown'),
+                Invocation::last(),
+                HasContent::no(),
+            ),
+            /**
+             * @see https://github.com/sebastianbergmann/phpunit/blob/6.0.0/src/Framework/TestCase.php#L2098-L2100
+             */
+            HookMethod::create(
+                ClassName::fromString(Framework\TestCase::class),
+                MethodName::fromString('tearDownAfterClass'),
+                Invocation::last(),
+                HasContent::no(),
+            ),
+            /**
+             * @see https://github.com/Codeception/phpunit-wrapper/blob/9.0.0/src/TestCase.php#L11-L13
+             */
+            HookMethod::create(
+                ClassName::fromString(PHPUnit\TestCase::class),
+                MethodName::fromString('_setUp'),
+                Invocation::first(),
+                HasContent::no(),
+            ),
+            /**
+             * @see https://github.com/Codeception/phpunit-wrapper/blob/9.0.0/src/TestCase.php#L25-L27
+             */
+            HookMethod::create(
+                ClassName::fromString(PHPUnit\TestCase::class),
+                MethodName::fromString('_setUpBeforeClass'),
+                Invocation::first(),
+                HasContent::no(),
+            ),
+            /**
+             * @see https://github.com/Codeception/phpunit-wrapper/blob/9.0.0/src/TestCase.php#L18-L20
+             */
+            HookMethod::create(
+                ClassName::fromString(PHPUnit\TestCase::class),
+                MethodName::fromString('_tearDown'),
+                Invocation::last(),
+                HasContent::no(),
+            ),
+            /**
+             * @see https://github.com/Codeception/phpunit-wrapper/blob/9.0.0/src/TestCase.php#L32-L34
+             */
+            HookMethod::create(
+                ClassName::fromString(PHPUnit\TestCase::class),
+                MethodName::fromString('_tearDownAfterClass'),
+                Invocation::last(),
+                HasContent::no(),
+            ),
+            /**
+             * @see https://github.com/Codeception/Codeception/blob/4.2.2/src/Codeception/Test/Unit.php#L75-L77
+             */
+            HookMethod::create(
+                ClassName::fromString(Test\Unit::class),
+                MethodName::fromString('_after'),
+                Invocation::last(),
+                HasContent::no(),
+            ),
+            /**
+             * @see https://github.com/Codeception/Codeception/blob/4.2.2/src/Codeception/Test/Unit.php#L63-L65
+             */
+            HookMethod::create(
+                ClassName::fromString(Test\Unit::class),
+                MethodName::fromString('_before'),
+                Invocation::first(),
+                HasContent::no(),
+            ),
+            /**
+             * @see https://github.com/Codeception/Codeception/blob/4.2.2/src/Codeception/Test/Unit.php#L34-L58
+             */
+            HookMethod::create(
+                ClassName::fromString(Test\Unit::class),
+                MethodName::fromString('_setUp'),
+                Invocation::first(),
+                HasContent::yes(),
+            ),
+            /**
+             * @see https://github.com/Codeception/Codeception/blob/4.2.2/src/Codeception/Test/Unit.php#L67-L70
+             */
+            HookMethod::create(
+                ClassName::fromString(Test\Unit::class),
+                MethodName::fromString('_tearDown'),
+                Invocation::last(),
+                HasContent::yes(),
+            ),
+        ];
+    }
+}

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Cest/AbstractCestCaseWithEmptyHookMethods.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Cest/AbstractCestCaseWithEmptyHookMethods.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Cest;
+
+abstract class AbstractCestCaseWithEmptyHookMethods
+{
+    public function _before(): void
+    {
+    }
+
+    public function _after(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Cest/AbstractCestCaseWithNonEmptyHookMethods.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Cest/AbstractCestCaseWithNonEmptyHookMethods.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Cest;
+
+abstract class AbstractCestCaseWithNonEmptyHookMethods
+{
+    public function _before(): void
+    {
+        self::setUpSomething();
+    }
+
+    public function _after(): void
+    {
+        self::tearDownSomething();
+    }
+
+    private static function setUpSomething(): void
+    {
+    }
+
+    private static function tearDownSomething(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Cest/ConcreteCestCaseInvokingNonEmptyParentHookMethodsInRightOrderCestHook.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Cest/ConcreteCestCaseInvokingNonEmptyParentHookMethodsInRightOrderCestHook.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Cest;
+
+class ConcreteCestCaseInvokingNonEmptyParentHookMethodsInRightOrderCestHook extends AbstractCestCaseWithNonEmptyHookMethods
+{
+    public function _before(): void
+    {
+        parent::_before();
+
+        self::setUpSomethingElse();
+    }
+
+    public function _after(): void
+    {
+        self::tearDownSomethingElse();
+
+        parent::_after();
+    }
+
+    private static function setUpSomethingElse(): void
+    {
+    }
+
+    private static function tearDownSomethingElse(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Cest/ConcreteCestCaseInvokingNonEmptyParentHookMethodsInWrongOrderCestHook.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Cest/ConcreteCestCaseInvokingNonEmptyParentHookMethodsInWrongOrderCestHook.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Cest;
+
+class ConcreteCestCaseInvokingNonEmptyParentHookMethodsInWrongOrderCestHook extends AbstractCestCaseWithNonEmptyHookMethods
+{
+    public function _before(): void
+    {
+        self::setUpSomethingElse();
+
+        parent::_before();
+    }
+
+    public function _after(): void
+    {
+        parent::_after();
+
+        self::tearDownSomethingElse();
+    }
+
+    private static function setUpSomethingElse(): void
+    {
+    }
+
+    private static function tearDownSomethingElse(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Cest/ConcreteCestCaseNotInvokingEmptyParentHookMethodsCestHook.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Cest/ConcreteCestCaseNotInvokingEmptyParentHookMethodsCestHook.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Cest;
+
+class ConcreteCestCaseNotInvokingEmptyParentHookMethodsCestHook extends AbstractCestCaseWithEmptyHookMethods
+{
+    public function _before(): void
+    {
+        self::setUpSomethingElse();
+    }
+
+    public function _after(): void
+    {
+        self::tearDownSomethingElse();
+    }
+
+    private static function setUpSomethingElse(): void
+    {
+    }
+
+    private static function tearDownSomethingElse(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Cest/ConcreteCestCaseNotInvokingNonEmptyParentHookMethodsCestHook.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Cest/ConcreteCestCaseNotInvokingNonEmptyParentHookMethodsCestHook.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Cest;
+
+class ConcreteCestCaseNotInvokingNonEmptyParentHookMethodsCestHook extends AbstractCestCaseWithNonEmptyHookMethods
+{
+    public function _before(): void
+    {
+        self::setUpSomethingElse();
+    }
+
+    public function _after(): void
+    {
+        self::tearDownSomethingElse();
+    }
+
+    private static function setUpSomethingElse(): void
+    {
+    }
+
+    private static function tearDownSomethingElse(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Test/AbstractTestCaseWithNonEmptyHookMethods.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Test/AbstractTestCaseWithNonEmptyHookMethods.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test;
+
+use Codeception\Test;
+
+abstract class AbstractTestCaseWithNonEmptyHookMethods extends Test\Unit
+{
+    protected function _before(): void
+    {
+        self::setUpSomething();
+    }
+
+    protected function _after(): void
+    {
+        self::tearDownSomething();
+    }
+
+    private static function setUpSomething(): void
+    {
+    }
+
+    private static function tearDownSomething(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Test/ConcreteTestCaseInvokingEmptyParentHookMethodsInRightOrderTest.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Test/ConcreteTestCaseInvokingEmptyParentHookMethodsInRightOrderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test;
+
+use Codeception\Test;
+
+class ConcreteTestCaseInvokingEmptyParentHookMethodsInRightOrderTest extends Test\Unit
+{
+    protected function _before(): void
+    {
+        parent::_before();
+
+        self::setUpSomethingElse();
+    }
+
+    protected function _after(): void
+    {
+        self::tearDownSomethingElse();
+
+        parent::_after();
+    }
+
+    private static function setUpSomethingElse(): void
+    {
+    }
+
+    private static function tearDownSomethingElse(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Test/ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Test/ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test;
+
+use Codeception\Test;
+
+class ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest extends Test\Unit
+{
+    protected function _before(): void
+    {
+        self::setUpSomethingElse();
+
+        parent::_before();
+    }
+
+    protected function _after(): void
+    {
+        parent::_after();
+
+        self::tearDownSomethingElse();
+    }
+
+    private static function setUpSomethingElse(): void
+    {
+    }
+
+    private static function tearDownSomethingElse(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Test/ConcreteTestCaseInvokingNonEmptyParentHookMethodsInRightOrderTest.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Test/ConcreteTestCaseInvokingNonEmptyParentHookMethodsInRightOrderTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test;
+
+class ConcreteTestCaseInvokingNonEmptyParentHookMethodsInRightOrderTest extends AbstractTestCaseWithNonEmptyHookMethods
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::setUpSomethingElse();
+    }
+
+    protected function tearDown(): void
+    {
+        self::tearDownSomethingElse();
+
+        parent::tearDown();
+    }
+
+    protected function _setUp(): void
+    {
+        parent::_setUp();
+
+        self::setUpSomethingElse();
+    }
+
+    protected function _tearDown(): void
+    {
+        self::tearDownSomethingElse();
+
+        parent::_tearDown();
+    }
+
+    protected function _before(): void
+    {
+        parent::_before();
+
+        self::setUpSomethingElse();
+    }
+
+    protected function _after(): void
+    {
+        self::tearDownSomethingElse();
+
+        parent::_after();
+    }
+
+    private static function setUpSomethingElse(): void
+    {
+    }
+
+    private static function tearDownSomethingElse(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Test/ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Test/ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test;
+
+class ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest extends AbstractTestCaseWithNonEmptyHookMethods
+{
+    protected function setUp(): void
+    {
+        self::setUpSomethingElse();
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        self::tearDownSomethingElse();
+    }
+
+    protected function _setUp(): void
+    {
+        self::setUpSomethingElse();
+
+        parent::_setUp();
+    }
+
+    protected function _tearDown(): void
+    {
+        parent::_tearDown();
+
+        self::tearDownSomethingElse();
+    }
+
+    protected function _before(): void
+    {
+        self::setUpSomethingElse();
+
+        parent::_before();
+    }
+
+    protected function _after(): void
+    {
+        parent::_after();
+
+        self::tearDownSomethingElse();
+    }
+
+    private static function setUpSomethingElse(): void
+    {
+    }
+
+    private static function tearDownSomethingElse(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Test/ConcreteTestCaseNotInvokingEmptyParentHookMethodsTest.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Test/ConcreteTestCaseNotInvokingEmptyParentHookMethodsTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test;
+
+use Codeception\Test;
+
+class ConcreteTestCaseNotInvokingEmptyParentHookMethodsTest extends Test\Unit
+{
+    protected function _before(): void
+    {
+    }
+
+    protected function _after(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Test/ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/Codeception/Test/ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test;
+
+class ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest extends AbstractTestCaseWithNonEmptyHookMethods
+{
+    protected function setUp(): void
+    {
+        self::setUpSomethingElse();
+    }
+
+    protected function tearDown(): void
+    {
+        self::tearDownSomethingElse();
+    }
+
+    protected function _setUp(): void
+    {
+        parent::_setUp();
+    }
+
+    protected function _tearDown(): void
+    {
+        self::tearDownSomethingElse();
+    }
+
+    protected function _before(): void
+    {
+        parent::_before();
+    }
+
+    protected function _after(): void
+    {
+        self::tearDownSomethingElse();
+    }
+
+    private static function setUpSomethingElse(): void
+    {
+    }
+
+    private static function tearDownSomethingElse(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/PHPUnit/Framework/AbstractTestCaseWithNonEmptyHookMethods.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/PHPUnit/Framework/AbstractTestCaseWithNonEmptyHookMethods.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework;
+
+use PHPUnit\Framework;
+
+abstract class AbstractTestCaseWithNonEmptyHookMethods extends Framework\TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        self::setUpSomething();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::tearDownSomething();
+    }
+
+    protected function setUp(): void
+    {
+        self::setUpSomething();
+    }
+
+    protected function assertPreConditions(): void
+    {
+        self::assertSomething();
+    }
+
+    protected function assertPostConditions(): void
+    {
+        self::assertSomething();
+    }
+
+    protected function tearDown(): void
+    {
+        self::tearDownSomething();
+    }
+
+    private static function setUpSomething(): void
+    {
+    }
+
+    private static function tearDownSomething(): void
+    {
+    }
+
+    private static function assertSomething(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/PHPUnit/Framework/ConcreteTestCaseInvokingEmptyParentHookMethodsInRightOrderTest.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/PHPUnit/Framework/ConcreteTestCaseInvokingEmptyParentHookMethodsInRightOrderTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework;
+
+use PHPUnit\Framework;
+
+class ConcreteTestCaseInvokingEmptyParentHookMethodsInRightOrderTest extends Framework\TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        self::setUpSomethingElse();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::tearDownSomethingElse();
+
+        parent::tearDownAfterClass();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::setUpSomethingElse();
+    }
+
+    protected function assertPreConditions(): void
+    {
+        parent::assertPreConditions();
+
+        self::assertSomethingElse();
+    }
+
+    protected function assertPostConditions(): void
+    {
+        self::assertSomethingElse();
+
+        parent::assertPostConditions();
+    }
+
+    protected function tearDown(): void
+    {
+        self::tearDownSomethingElse();
+
+        parent::tearDown();
+    }
+
+    private static function setUpSomethingElse(): void
+    {
+    }
+
+    private static function tearDownSomethingElse(): void
+    {
+    }
+
+    private static function assertSomethingElse(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/PHPUnit/Framework/ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/PHPUnit/Framework/ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework;
+
+use PHPUnit\Framework;
+
+class ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest extends Framework\TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        self::setUpSomethingElse();
+
+        parent::setUpBeforeClass();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+
+        self::tearDownSomethingElse();
+    }
+
+    protected function setUp(): void
+    {
+        self::setUpSomethingElse();
+
+        parent::setUp();
+    }
+
+    protected function assertPreConditions(): void
+    {
+        self::assertSomethingElse();
+
+        parent::assertPreConditions();
+    }
+
+    protected function assertPostConditions(): void
+    {
+        parent::assertPostConditions();
+
+        self::assertSomethingElse();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        self::tearDownSomethingElse();
+    }
+
+    private static function setUpSomethingElse(): void
+    {
+    }
+
+    private static function tearDownSomethingElse(): void
+    {
+    }
+
+    private static function assertSomethingElse(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/PHPUnit/Framework/ConcreteTestCaseInvokingNonEmptyParentHookMethodsInRightOrderTest.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/PHPUnit/Framework/ConcreteTestCaseInvokingNonEmptyParentHookMethodsInRightOrderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework;
+
+class ConcreteTestCaseInvokingNonEmptyParentHookMethodsInRightOrderTest extends AbstractTestCaseWithNonEmptyHookMethods
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        self::setUpSomethingElse();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::tearDownSomethingElse();
+
+        parent::tearDownAfterClass();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::setUpSomethingElse();
+    }
+
+    protected function assertPreConditions(): void
+    {
+        parent::assertPreConditions();
+
+        self::assertSomethingElse();
+    }
+
+    protected function assertPostConditions(): void
+    {
+        self::assertSomethingElse();
+
+        parent::assertPostConditions();
+    }
+
+    protected function tearDown(): void
+    {
+        self::tearDownSomethingElse();
+
+        parent::tearDown();
+    }
+
+    private static function setUpSomethingElse(): void
+    {
+    }
+
+    private static function tearDownSomethingElse(): void
+    {
+    }
+
+    private static function assertSomethingElse(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/PHPUnit/Framework/ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/PHPUnit/Framework/ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework;
+
+class ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest extends AbstractTestCaseWithNonEmptyHookMethods
+{
+    public static function setUpBeforeClass(): void
+    {
+        self::setUpSomethingElse();
+
+        parent::setUpBeforeClass();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+
+        self::tearDownSomethingElse();
+    }
+
+    protected function setUp(): void
+    {
+        self::setUpSomethingElse();
+
+        parent::setUp();
+    }
+
+    protected function assertPreConditions(): void
+    {
+        self::assertSomethingElse();
+
+        parent::assertPreConditions();
+    }
+
+    protected function assertPostConditions(): void
+    {
+        parent::assertPostConditions();
+
+        self::assertSomethingElse();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        self::tearDownSomethingElse();
+    }
+
+    private static function setUpSomethingElse(): void
+    {
+    }
+
+    private static function tearDownSomethingElse(): void
+    {
+    }
+
+    private static function assertSomethingElse(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/PHPUnit/Framework/ConcreteTestCaseNotInvokingEmptyParentHookMethodsTest.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/PHPUnit/Framework/ConcreteTestCaseNotInvokingEmptyParentHookMethodsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework;
+
+use PHPUnit\Framework;
+
+class ConcreteTestCaseNotInvokingEmptyParentHookMethodsTest extends Framework\TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+    }
+
+    protected function setUp(): void
+    {
+    }
+
+    protected function assertPreConditions(): void
+    {
+    }
+
+    protected function assertPostConditions(): void
+    {
+    }
+
+    protected function tearDown(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/PHPUnit/Framework/ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/PHPUnit/Framework/ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework;
+
+class ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest extends AbstractTestCaseWithNonEmptyHookMethods
+{
+    public static function setUpBeforeClass(): void
+    {
+        self::setUpSomethingElse();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::tearDownSomethingElse();
+    }
+
+    protected function setUp(): void
+    {
+        self::setUpSomethingElse();
+    }
+
+    protected function assertPreConditions(): void
+    {
+        self::assertSomethingElse();
+    }
+
+    protected function assertPostConditions(): void
+    {
+        self::assertSomethingElse();
+    }
+
+    protected function tearDown(): void
+    {
+        self::tearDownSomethingElse();
+    }
+
+    private static function setUpSomethingElse(): void
+    {
+    }
+
+    private static function tearDownSomethingElse(): void
+    {
+    }
+
+    private static function assertSomethingElse(): void
+    {
+    }
+}

--- a/test/Integration/Methods/InvokeParentHookMethodRuleWithCustomConfigurationTest.php
+++ b/test/Integration/Methods/InvokeParentHookMethodRuleWithCustomConfigurationTest.php
@@ -1,0 +1,316 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2025 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpstan-rules
+ */
+
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Methods;
+
+use Ergebnis\PHPStan\Rules\Methods;
+use Ergebnis\PHPStan\Rules\Test;
+use PHPStan\Rules;
+use PHPStan\Testing;
+
+/**
+ * @covers \Ergebnis\PHPStan\Rules\Methods\InvokeParentHookMethodRule
+ *
+ * @uses \Ergebnis\PHPStan\Rules\ClassName
+ * @uses \Ergebnis\PHPStan\Rules\ErrorIdentifier
+ * @uses \Ergebnis\PHPStan\Rules\HasContent
+ * @uses \Ergebnis\PHPStan\Rules\HookMethod
+ * @uses \Ergebnis\PHPStan\Rules\Invocation
+ * @uses \Ergebnis\PHPStan\Rules\MethodName
+ *
+ * @extends Testing\RuleTestCase<Methods\InvokeParentHookMethodRule>
+ */
+final class InvokeParentHookMethodRuleWithCustomConfigurationTest extends Testing\RuleTestCase
+{
+    use Test\Util\Helper;
+
+    public function testInvokeParentHookMethodRuleWithCustomConfiguration(): void
+    {
+        $this->analyse(
+            self::phpFilesIn(__DIR__ . '/../../Fixture/Methods/InvokeParentHookMethodRule'),
+            [
+                [
+                    \sprintf(
+                        'Method %s::_before() does not invoke parent::_before() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Cest\ConcreteCestCaseInvokingNonEmptyParentHookMethodsInWrongOrderCestHook::class,
+                    ),
+                    9,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::_after() does not invoke parent::_after() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Cest\ConcreteCestCaseInvokingNonEmptyParentHookMethodsInWrongOrderCestHook::class,
+                    ),
+                    16,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::_before() does not invoke parent::_before().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Cest\ConcreteCestCaseNotInvokingNonEmptyParentHookMethodsCestHook::class,
+                    ),
+                    9,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::_after() does not invoke parent::_after().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Cest\ConcreteCestCaseNotInvokingNonEmptyParentHookMethodsCestHook::class,
+                    ),
+                    14,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::_before() does not invoke parent::_before() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    11,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::_after() does not invoke parent::_after() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    18,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::setUp() does not invoke parent::setUp() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    9,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::tearDown() does not invoke parent::tearDown() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    16,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::_setUp() does not invoke parent::_setUp() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    23,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::_tearDown() does not invoke parent::_tearDown() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    30,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::_before() does not invoke parent::_before() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    37,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::_after() does not invoke parent::_after() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    44,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::setUp() does not invoke parent::setUp().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest::class,
+                    ),
+                    9,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::tearDown() does not invoke parent::tearDown().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest::class,
+                    ),
+                    14,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::_tearDown() does not invoke parent::_tearDown().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest::class,
+                    ),
+                    24,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::_after() does not invoke parent::_after().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest::class,
+                    ),
+                    34,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::setUpBeforeClass() does not invoke parent::setUpBeforeClass() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    11,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::tearDownAfterClass() does not invoke parent::tearDownAfterClass() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    18,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::setUp() does not invoke parent::setUp() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    25,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::assertPreConditions() does not invoke parent::assertPreConditions() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    32,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::assertPostConditions() does not invoke parent::assertPostConditions() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    39,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::tearDown() does not invoke parent::tearDown() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    46,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::setUpBeforeClass() does not invoke parent::setUpBeforeClass() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    9,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::tearDownAfterClass() does not invoke parent::tearDownAfterClass() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    16,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::setUp() does not invoke parent::setUp() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    23,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::assertPreConditions() does not invoke parent::assertPreConditions() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    30,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::assertPostConditions() does not invoke parent::assertPostConditions() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    37,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::tearDown() does not invoke parent::tearDown() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    44,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::setUpBeforeClass() does not invoke parent::setUpBeforeClass().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest::class,
+                    ),
+                    9,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::tearDownAfterClass() does not invoke parent::tearDownAfterClass().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest::class,
+                    ),
+                    14,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::setUp() does not invoke parent::setUp().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest::class,
+                    ),
+                    19,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::assertPreConditions() does not invoke parent::assertPreConditions().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest::class,
+                    ),
+                    24,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::assertPostConditions() does not invoke parent::assertPostConditions().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest::class,
+                    ),
+                    29,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::tearDown() does not invoke parent::tearDown().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest::class,
+                    ),
+                    34,
+                ],
+            ],
+        );
+    }
+
+    protected function getRule(): Rules\Rule
+    {
+        return new Methods\InvokeParentHookMethodRule(
+            self::createReflectionProvider(),
+            [
+                [
+                    'className' => Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Cest\AbstractCestCaseWithEmptyHookMethods::class,
+                    'hasContent' => 'no',
+                    'invocation' => 'first',
+                    'methodName' => '_before',
+                ],
+                [
+                    'className' => Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Cest\AbstractCestCaseWithEmptyHookMethods::class,
+                    'hasContent' => 'no',
+                    'invocation' => 'last',
+                    'methodName' => '_after',
+                ],
+                [
+                    'className' => Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Cest\AbstractCestCaseWithNonEmptyHookMethods::class,
+                    'hasContent' => 'yes',
+                    'invocation' => 'first',
+                    'methodName' => '_before',
+                ],
+                [
+                    'className' => Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Cest\AbstractCestCaseWithNonEmptyHookMethods::class,
+                    'hasContent' => 'yes',
+                    'invocation' => 'last',
+                    'methodName' => '_after',
+                ],
+            ],
+        );
+    }
+}

--- a/test/Integration/Methods/InvokeParentHookMethodRuleWithDefaultConfigurationTest.php
+++ b/test/Integration/Methods/InvokeParentHookMethodRuleWithDefaultConfigurationTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2025 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpstan-rules
+ */
+
+namespace Ergebnis\PHPStan\Rules\Test\Integration\Methods;
+
+use Ergebnis\PHPStan\Rules\Methods;
+use Ergebnis\PHPStan\Rules\Test;
+use PHPStan\Rules;
+use PHPStan\Testing;
+
+/**
+ * @covers \Ergebnis\PHPStan\Rules\Methods\InvokeParentHookMethodRule
+ *
+ * @uses \Ergebnis\PHPStan\Rules\ClassName
+ * @uses \Ergebnis\PHPStan\Rules\ErrorIdentifier
+ * @uses \Ergebnis\PHPStan\Rules\HasContent
+ * @uses \Ergebnis\PHPStan\Rules\HookMethod
+ * @uses \Ergebnis\PHPStan\Rules\Invocation
+ * @uses \Ergebnis\PHPStan\Rules\MethodName
+ *
+ * @extends Testing\RuleTestCase<Methods\InvokeParentHookMethodRule>
+ */
+final class InvokeParentHookMethodRuleWithDefaultConfigurationTest extends Testing\RuleTestCase
+{
+    use Test\Util\Helper;
+
+    public function testInvokeParentHookMethodRuleWithDefaultConfiguration(): void
+    {
+        $this->analyse(
+            self::phpFilesIn(__DIR__ . '/../../Fixture/Methods/InvokeParentHookMethodRule'),
+            [
+                [
+                    \sprintf(
+                        'Method %s::_before() does not invoke parent::_before() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    11,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::_after() does not invoke parent::_after() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    18,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::setUp() does not invoke parent::setUp() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    9,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::tearDown() does not invoke parent::tearDown() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    16,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::_setUp() does not invoke parent::_setUp() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    23,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::_tearDown() does not invoke parent::_tearDown() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    30,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::_before() does not invoke parent::_before() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    37,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::_after() does not invoke parent::_after() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    44,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::setUp() does not invoke parent::setUp().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest::class,
+                    ),
+                    9,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::tearDown() does not invoke parent::tearDown().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest::class,
+                    ),
+                    14,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::_tearDown() does not invoke parent::_tearDown().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest::class,
+                    ),
+                    24,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::_after() does not invoke parent::_after().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\Codeception\Test\ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest::class,
+                    ),
+                    34,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::setUpBeforeClass() does not invoke parent::setUpBeforeClass() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    11,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::tearDownAfterClass() does not invoke parent::tearDownAfterClass() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    18,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::setUp() does not invoke parent::setUp() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    25,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::assertPreConditions() does not invoke parent::assertPreConditions() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    32,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::assertPostConditions() does not invoke parent::assertPostConditions() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    39,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::tearDown() does not invoke parent::tearDown() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    46,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::setUpBeforeClass() does not invoke parent::setUpBeforeClass() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    9,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::tearDownAfterClass() does not invoke parent::tearDownAfterClass() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    16,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::setUp() does not invoke parent::setUp() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    23,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::assertPreConditions() does not invoke parent::assertPreConditions() before all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    30,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::assertPostConditions() does not invoke parent::assertPostConditions() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    37,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::tearDown() does not invoke parent::tearDown() after all other statements.',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseInvokingNonEmptyParentHookMethodsInWrongOrderTest::class,
+                    ),
+                    44,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::setUpBeforeClass() does not invoke parent::setUpBeforeClass().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest::class,
+                    ),
+                    9,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::tearDownAfterClass() does not invoke parent::tearDownAfterClass().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest::class,
+                    ),
+                    14,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::setUp() does not invoke parent::setUp().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest::class,
+                    ),
+                    19,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::assertPreConditions() does not invoke parent::assertPreConditions().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest::class,
+                    ),
+                    24,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::assertPostConditions() does not invoke parent::assertPostConditions().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest::class,
+                    ),
+                    29,
+                ],
+                [
+                    \sprintf(
+                        'Method %s::tearDown() does not invoke parent::tearDown().',
+                        Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework\ConcreteTestCaseNotInvokingNonEmptyParentHookMethodsTest::class,
+                    ),
+                    34,
+                ],
+            ],
+        );
+    }
+
+    protected function getRule(): Rules\Rule
+    {
+        return new Methods\InvokeParentHookMethodRule(self::createReflectionProvider());
+    }
+}

--- a/test/Unit/ClassNameTest.php
+++ b/test/Unit/ClassNameTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2025 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpstan-rules
+ */
+
+namespace Ergebnis\PHPStan\Rules\Test\Unit;
+
+use Ergebnis\PHPStan\Rules\ClassName;
+use PHPUnit\Framework;
+
+/**
+ * @covers \Ergebnis\PHPStan\Rules\ClassName
+ */
+final class ClassNameTest extends Framework\TestCase
+{
+    public function testFromStringReturnsClassName(): void
+    {
+        $value = self::class;
+
+        $className = ClassName::fromString($value);
+
+        self::assertSame($value, $className->toString());
+    }
+
+    public function testEqualsReturnsFalseWhenValuesAreDifferent(): void
+    {
+        $one = ClassName::fromString(self::class);
+        $two = ClassName::fromString(Framework\TestCase::class);
+
+        self::assertFalse($one->equals($two));
+    }
+
+    public function testEqualsReturnsTrueWhenValueIsSame(): void
+    {
+        $value = self::class;
+
+        $one = ClassName::fromString($value);
+        $two = ClassName::fromString($value);
+
+        self::assertTrue($one->equals($two));
+    }
+}

--- a/test/Unit/ErrorIdentifierTest.php
+++ b/test/Unit/ErrorIdentifierTest.php
@@ -42,6 +42,13 @@ final class ErrorIdentifierTest extends Framework\TestCase
         self::assertSame('ergebnis.final', $errorIdentifier->toString());
     }
 
+    public function testInvokeParentMethodReturnsErrorIdentifier(): void
+    {
+        $errorIdentifier = ErrorIdentifier::invokeParentMethod();
+
+        self::assertSame('ergebnis.invokeParentMethod', $errorIdentifier->toString());
+    }
+
     public function testNoAssignByReferenceReturnsErrorIdentifier(): void
     {
         $errorIdentifier = ErrorIdentifier::noAssignByReference();

--- a/test/Unit/HasContentTest.php
+++ b/test/Unit/HasContentTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2025 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpstan-rules
+ */
+
+namespace Ergebnis\PHPStan\Rules\Test\Unit;
+
+use Ergebnis\PHPStan\Rules\HasContent;
+use Ergebnis\PHPStan\Rules\Test;
+use PHPUnit\Framework;
+
+/**
+ * @covers \Ergebnis\PHPStan\Rules\HasContent
+ */
+final class HasContentTest extends Framework\TestCase
+{
+    use Test\Util\Helper;
+
+    public function testMaybeReturnsHasContent(): void
+    {
+        $hasContent = HasContent::maybe();
+
+        self::assertSame('maybe', $hasContent->toString());
+    }
+
+    public function testNoReturnsHasContent(): void
+    {
+        $hasContent = HasContent::no();
+
+        self::assertSame('no', $hasContent->toString());
+    }
+
+    public function testYesReturnsHasContent(): void
+    {
+        $hasContent = HasContent::yes();
+
+        self::assertSame('yes', $hasContent->toString());
+    }
+
+    public function testFromStringRejectsUnknownValue(): void
+    {
+        $value = self::faker()->slug();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Value needs to be one of "maybe", "no", "yes", got "%s" instead.',
+            $value,
+        ));
+
+        HasContent::fromString($value);
+    }
+
+    /**
+     * @dataProvider provideValue
+     */
+    public function testFromStringReturnsOrder(string $value): void
+    {
+        $order = HasContent::fromString($value);
+
+        self::assertSame($value, $order->toString());
+    }
+
+    /**
+     * @return \Generator<string, array{0: string}>
+     */
+    public static function provideValue(): iterable
+    {
+        $values = [
+            'maybe',
+            'no',
+            'yes',
+        ];
+
+        foreach ($values as $value) {
+            yield $value => [
+                $value,
+            ];
+        }
+    }
+
+    public function testEqualsReturnsFalseWhenValuesAreDifferent(): void
+    {
+        $one = HasContent::yes();
+        $two = HasContent::no();
+
+        self::assertFalse($one->equals($two));
+    }
+
+    public function testEqualsReturnsTrueWhenValueIsSame(): void
+    {
+        $one = HasContent::maybe();
+        $two = HasContent::maybe();
+
+        self::assertTrue($one->equals($two));
+    }
+}

--- a/test/Unit/HookMethodTest.php
+++ b/test/Unit/HookMethodTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2025 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpstan-rules
+ */
+
+namespace Ergebnis\PHPStan\Rules\Test\Unit;
+
+use Ergebnis\PHPStan\Rules\ClassName;
+use Ergebnis\PHPStan\Rules\HasContent;
+use Ergebnis\PHPStan\Rules\HookMethod;
+use Ergebnis\PHPStan\Rules\Invocation;
+use Ergebnis\PHPStan\Rules\MethodName;
+use Ergebnis\PHPStan\Rules\Test;
+use PHPUnit\Framework;
+
+/**
+ * @covers \Ergebnis\PHPStan\Rules\HookMethod
+ *
+ * @uses \Ergebnis\PHPStan\Rules\ClassName
+ * @uses \Ergebnis\PHPStan\Rules\HasContent
+ * @uses \Ergebnis\PHPStan\Rules\Invocation
+ * @uses \Ergebnis\PHPStan\Rules\MethodName
+ */
+final class HookMethodTest extends Framework\TestCase
+{
+    use Test\Util\Helper;
+
+    public function testCreateReturnsHookMethod(): void
+    {
+        $faker = self::faker();
+
+        $className = ClassName::fromString(self::class);
+        $methodName = MethodName::fromString(__FUNCTION__);
+        $invocation = $faker->randomElement([
+            Invocation::last(),
+            Invocation::any(),
+            Invocation::first(),
+        ]);
+        $hasContent = $faker->randomElement([
+            HasContent::maybe(),
+            HasContent::no(),
+            HasContent::yes(),
+        ]);
+
+        $hookMethod = HookMethod::create(
+            $className,
+            $methodName,
+            $invocation,
+            $hasContent,
+        );
+
+        self::assertSame($className, $hookMethod->className());
+        self::assertSame($methodName, $hookMethod->methodName());
+        self::assertSame($invocation, $hookMethod->invocation());
+        self::assertSame($hasContent, $hookMethod->hasContent());
+    }
+}

--- a/test/Unit/InvocationTest.php
+++ b/test/Unit/InvocationTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2025 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpstan-rules
+ */
+
+namespace Ergebnis\PHPStan\Rules\Test\Unit;
+
+use Ergebnis\PHPStan\Rules\Invocation;
+use Ergebnis\PHPStan\Rules\Test;
+use PHPUnit\Framework;
+
+/**
+ * @covers \Ergebnis\PHPStan\Rules\Invocation
+ */
+final class InvocationTest extends Framework\TestCase
+{
+    use Test\Util\Helper;
+
+    public function testAnyReturnsInvocation(): void
+    {
+        $invocation = Invocation::any();
+
+        self::assertSame('any', $invocation->toString());
+    }
+
+    public function testFirstReturnsOrder(): void
+    {
+        $invocation = Invocation::first();
+
+        self::assertSame('first', $invocation->toString());
+    }
+
+    public function testLastReturnsInvocation(): void
+    {
+        $invocation = Invocation::last();
+
+        self::assertSame('last', $invocation->toString());
+    }
+
+    public function testNeverReturnsInvocation(): void
+    {
+        $invocation = Invocation::never();
+
+        self::assertSame('never', $invocation->toString());
+    }
+
+    public function testFromStringRejectsUnknownValue(): void
+    {
+        $value = self::faker()->slug();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Value needs to be one of "any", "first", "last", "never", got "%s" instead.',
+            $value,
+        ));
+
+        Invocation::fromString($value);
+    }
+
+    /**
+     * @dataProvider provideValue
+     */
+    public function testFromStringReturnsOrder(string $value): void
+    {
+        $order = Invocation::fromString($value);
+
+        self::assertSame($value, $order->toString());
+    }
+
+    /**
+     * @return \Generator<string, array{0: string}>
+     */
+    public static function provideValue(): iterable
+    {
+        $values = [
+            'any',
+            'first',
+            'last',
+            'never',
+        ];
+
+        foreach ($values as $value) {
+            yield $value => [
+                $value,
+            ];
+        }
+    }
+
+    public function testEqualsReturnsFalseWhenValuesAreDifferent(): void
+    {
+        $one = Invocation::any();
+        $two = Invocation::last();
+
+        self::assertFalse($one->equals($two));
+    }
+
+    /**
+     * @dataProvider provideValue
+     */
+    public function testEqualsReturnsTrueWhenValueIsSame(string $value): void
+    {
+        $one = Invocation::fromString($value);
+        $two = Invocation::fromString($value);
+
+        self::assertTrue($one->equals($two));
+    }
+}

--- a/test/Unit/MethodNameTest.php
+++ b/test/Unit/MethodNameTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2025 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/phpstan-rules
+ */
+
+namespace Ergebnis\PHPStan\Rules\Test\Unit;
+
+use Ergebnis\PHPStan\Rules\MethodName;
+use PHPUnit\Framework;
+
+/**
+ * @covers \Ergebnis\PHPStan\Rules\MethodName
+ */
+final class MethodNameTest extends Framework\TestCase
+{
+    public function testFromStringReturnsMethodName(): void
+    {
+        $value = __FUNCTION__;
+
+        $methodName = MethodName::fromString($value);
+
+        self::assertSame($value, $methodName->toString());
+    }
+
+    public function testEqualsReturnsFalseWhenValuesAreDifferent(): void
+    {
+        $one = MethodName::fromString(__FUNCTION__);
+        $two = MethodName::fromString('tearDown');
+
+        self::assertFalse($one->equals($two));
+    }
+
+    public function testEqualsReturnsTrueWhenValueIsSame(): void
+    {
+        $value = __FUNCTION__;
+
+        $one = MethodName::fromString($value);
+        $two = MethodName::fromString($value);
+
+        self::assertTrue($one->equals($two));
+    }
+}

--- a/test/Util/Helper.php
+++ b/test/Util/Helper.php
@@ -13,10 +13,30 @@ declare(strict_types=1);
 
 namespace Ergebnis\PHPStan\Rules\Test\Util;
 
+use Faker\Factory;
+use Faker\Generator;
 use Symfony\Component\Finder;
 
 trait Helper
 {
+    final protected static function faker(string $locale = 'en_US'): Generator
+    {
+        /**
+         * @var array<string, Generator> $fakers
+         */
+        static $fakers = [];
+
+        if (!\array_key_exists($locale, $fakers)) {
+            $faker = Factory::create($locale);
+
+            $faker->seed(9001);
+
+            $fakers[$locale] = $faker;
+        }
+
+        return $fakers[$locale];
+    }
+
     /**
      * @return list<string>
      */


### PR DESCRIPTION
This pull request

- [x] implements an `InvokeParentHookMethodRule`, which  an error when a hook method that overrides a hook method in a parent class does not invoke the overridden hook method in the expected order