### PR TITLE
Fix: Use `Invocation::never()`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -61,12 +61,6 @@ parameters:
 			path: src/Methods/InvokeParentHookMethodRule.php
 
 		-
-			message: '#^Method Ergebnis\\PHPStan\\Rules\\Methods\\InvokeParentHookMethodRule\:\:findParentHookMethodInvocation\(\) has a nullable return type declaration\.$#'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: src/Methods/InvokeParentHookMethodRule.php
-
-		-
 			message: '#^Parameter \#1 \$value of static method Ergebnis\\PHPStan\\Rules\\ClassName\:\:fromString\(\) expects class\-string, string given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Methods/InvokeParentHookMethodRule.php
+++ b/src/Methods/InvokeParentHookMethodRule.php
@@ -112,7 +112,7 @@ final class InvokeParentHookMethodRule implements Rules\Rule
             $hookMethod,
         );
 
-        if (!$parentHookMethodInvocation instanceof Invocation) {
+        if ($parentHookMethodInvocation->equals(Invocation::never())) {
             if ($hookMethod->hasContent()->equals(HasContent::no())) {
                 return [];
             }
@@ -211,7 +211,7 @@ final class InvokeParentHookMethodRule implements Rules\Rule
     private static function findParentHookMethodInvocation(
         array $statements,
         HookMethod $hookMethod
-    ): ?Invocation {
+    ): Invocation {
         $statementCount = \count($statements);
 
         foreach ($statements as $index => $statement) {
@@ -254,7 +254,7 @@ final class InvokeParentHookMethodRule implements Rules\Rule
             }
         }
 
-        return null;
+        return Invocation::never();
     }
 
     /**


### PR DESCRIPTION
This pull request

- [x] uses `Invocation::never()`

Follows #939.