### PR TITLE
Fix: Disallow configuring `never` invocation

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -130,7 +130,7 @@ parametersSchema:
 			hookMethods: listOf(structure([
 				className: string(),
 				hasContent: anyOf("no", "yes"),
-				invocation: anyOf("any", "first", "last", "never"),
+				invocation: anyOf("any", "first", "last"),
 				methodName: string(),
 			]))
 		])


### PR DESCRIPTION
This pull request

- [x] disallows configuring a `never` invocation