### PR TITLE
Fix: Rename error identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.10.1...main`][2.10.1...main].
 
+### Fixed
+
+- Renamed error identifier for `Methods\InvokeParentHookMethodRule` ([#943]), by [@localheinz]
+
 ## [`2.10.1`][2.10.1]
 
 For a full diff see [`2.10.0...2.10.1`][2.10.0...2.10.1].
@@ -662,6 +666,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [#938]: https://github.com/ergebnis/phpstan-rules/pull/938
 [#939]: https://github.com/ergebnis/phpstan-rules/pull/939
 [#940]: https://github.com/ergebnis/phpstan-rules/pull/940
+[#943]: https://github.com/ergebnis/phpstan-rules/pull/943
 
 [@cosmastech]: https://github.com/cosmastech
 [@enumag]: https://github.com/enumag

--- a/src/ErrorIdentifier.php
+++ b/src/ErrorIdentifier.php
@@ -40,9 +40,9 @@ final class ErrorIdentifier
         return new self('finalInAbstractClass');
     }
 
-    public static function invokeParentMethod(): self
+    public static function invokeParentHookMethod(): self
     {
-        return new self('invokeParentMethod');
+        return new self('invokeParentHookMethod');
     }
 
     public static function noCompact(): self

--- a/src/Methods/InvokeParentHookMethodRule.php
+++ b/src/Methods/InvokeParentHookMethodRule.php
@@ -126,7 +126,7 @@ final class InvokeParentHookMethodRule implements Rules\Rule
 
             return [
                 Rules\RuleErrorBuilder::message($message)
-                    ->identifier(ErrorIdentifier::invokeParentMethod()->toString())
+                    ->identifier(ErrorIdentifier::invokeParentHookMethod()->toString())
                     ->build(),
             ];
         }
@@ -145,7 +145,7 @@ final class InvokeParentHookMethodRule implements Rules\Rule
 
             return [
                 Rules\RuleErrorBuilder::message($message)
-                    ->identifier(ErrorIdentifier::invokeParentMethod()->toString())
+                    ->identifier(ErrorIdentifier::invokeParentHookMethod()->toString())
                     ->build(),
             ];
         }
@@ -160,7 +160,7 @@ final class InvokeParentHookMethodRule implements Rules\Rule
 
             return [
                 Rules\RuleErrorBuilder::message($message)
-                    ->identifier(ErrorIdentifier::invokeParentMethod()->toString())
+                    ->identifier(ErrorIdentifier::invokeParentHookMethod()->toString())
                     ->build(),
             ];
         }

--- a/test/Unit/ErrorIdentifierTest.php
+++ b/test/Unit/ErrorIdentifierTest.php
@@ -42,11 +42,11 @@ final class ErrorIdentifierTest extends Framework\TestCase
         self::assertSame('ergebnis.final', $errorIdentifier->toString());
     }
 
-    public function testInvokeParentMethodReturnsErrorIdentifier(): void
+    public function testInvokeParentHookMethodReturnsErrorIdentifier(): void
     {
-        $errorIdentifier = ErrorIdentifier::invokeParentMethod();
+        $errorIdentifier = ErrorIdentifier::invokeParentHookMethod();
 
-        self::assertSame('ergebnis.invokeParentMethod', $errorIdentifier->toString());
+        self::assertSame('ergebnis.invokeParentHookMethod', $errorIdentifier->toString());
     }
 
     public function testNoAssignByReferenceReturnsErrorIdentifier(): void


### PR DESCRIPTION
This pull request

- [x] renames an error identifier

Follows #939.