### PR TITLE
Fix: Ignore comments in `InvokeParentHookMethodRule`

### DIFF
--- a/.php-cs-fixer.fixture.php
+++ b/.php-cs-fixer.fixture.php
@@ -28,7 +28,9 @@ $ruleSet = PhpCsFixer\Config\RuleSet\Php74::create()
         'native_function_casing' => false,
         'native_function_invocation' => false,
         'nullable_type_declaration' => false,
+        'phpdoc_summary' => false,
         'protected_to_private' => false,
+        'single_line_comment_style' => false,
         'static_lambda' => false,
     ]));
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.10.2...main`][2.10.2...main].
 
+### Fixed
+
+- Adjusted `Methods\InvokeParentHookMethodRule` to ignore comments ([#943]), by [@localheinz]
+
+
 ## [`2.10.2`][2.10.2]
 
 For a full diff see [`2.10.1...2.10.2`][2.10.1...2.10.2].

--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -35,6 +35,7 @@
     "PhpParser\\Node\\Stmt\\Expression",
     "PhpParser\\Node\\Stmt\\Function_",
     "PhpParser\\Node\\Stmt\\InlineHTML",
+    "PhpParser\\Node\\Stmt\\Nop",
     "PhpParser\\Node\\Stmt\\Switch_",
     "PhpParser\\Node\\UnionType",
     "PHPStan\\Analyser\\Scope",

--- a/src/Methods/InvokeParentHookMethodRule.php
+++ b/src/Methods/InvokeParentHookMethodRule.php
@@ -212,9 +212,17 @@ final class InvokeParentHookMethodRule implements Rules\Rule
         array $statements,
         HookMethod $hookMethod
     ): Invocation {
-        $statementCount = \count($statements);
+        $statementsWithOperations = \array_filter($statements, static function (Node $statement): bool {
+            if ($statement instanceof Node\Stmt\Nop) {
+                return false;
+            }
 
-        foreach ($statements as $index => $statement) {
+            return true;
+        });
+
+        $statementCount = \count($statementsWithOperations);
+
+        foreach ($statementsWithOperations as $index => $statement) {
             if (!$statement instanceof Node\Stmt\Expression) {
                 continue;
             }

--- a/test/Fixture/Methods/InvokeParentHookMethodRule/PHPUnit/Framework/ConcreteTestCaseInvokingNonEmptyParentHookMethodsInRightOrderWithCommentsTest.php
+++ b/test/Fixture/Methods/InvokeParentHookMethodRule/PHPUnit/Framework/ConcreteTestCaseInvokingNonEmptyParentHookMethodsInRightOrderWithCommentsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\Methods\InvokeParentHookMethodRule\PHPUnit\Framework;
+
+class ConcreteTestCaseInvokingNonEmptyParentHookMethodsInRightOrderWithCommentsTest extends AbstractTestCaseWithNonEmptyHookMethods
+{
+    public static function setUpBeforeClass(): void
+    {
+        // hmm
+
+        parent::setUpBeforeClass();
+
+        self::setUpSomethingElse();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::tearDownSomethingElse();
+
+        parent::tearDownAfterClass();
+
+        // hmm
+    }
+
+    protected function setUp(): void
+    {
+        # hmm
+
+        parent::setUp();
+
+        self::setUpSomethingElse();
+    }
+
+    protected function assertPreConditions(): void
+    {
+        # hmm
+
+        parent::assertPreConditions();
+
+        self::assertSomethingElse();
+    }
+
+    protected function assertPostConditions(): void
+    {
+        self::assertSomethingElse();
+
+        parent::assertPostConditions();
+
+        /**
+         * hmm
+         */
+    }
+
+    protected function tearDown(): void
+    {
+        self::tearDownSomethingElse();
+
+        parent::tearDown();
+
+        /**
+         * hmm
+         */
+    }
+
+    private static function setUpSomethingElse(): void
+    {
+    }
+
+    private static function tearDownSomethingElse(): void
+    {
+    }
+
+    private static function assertSomethingElse(): void
+    {
+    }
+}


### PR DESCRIPTION
This pull request

- [x] ignore comments in the `InvokeParentHookMethodRule`