### PR TITLE
Fix: Adjust `CallLikes\NoNamedArgumentRule` to handle `static` calls on variable expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.10.3...main`][2.10.3...main].
 
+### Fixed
+
+- Adjusted `Methods\NoNamedArgumentRule` to handle static calls on variable expressions ([#947]), by [@localheinz]
+
 ## [`2.10.3`][2.10.3]
 
 For a full diff see [`2.10.2...2.10.3`][2.10.2...2.10.3].
@@ -684,6 +688,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [#940]: https://github.com/ergebnis/phpstan-rules/pull/940
 [#943]: https://github.com/ergebnis/phpstan-rules/pull/943
 [#944]: https://github.com/ergebnis/phpstan-rules/pull/944
+[#947]: https://github.com/ergebnis/phpstan-rules/pull/947
 
 [@cosmastech]: https://github.com/cosmastech
 [@enumag]: https://github.com/enumag

--- a/src/CallLikes/NoNamedArgumentRule.php
+++ b/src/CallLikes/NoNamedArgumentRule.php
@@ -139,7 +139,26 @@ final class NoNamedArgumentRule implements Rules\Rule
 
         if ($node instanceof Node\Expr\StaticCall) {
             $className = $node->class;
+
+            /** @var Node\Identifier $methodName */
             $methodName = $node->name;
+
+            if ($className instanceof Node\Expr\Variable) {
+                return \array_map(static function (Node\Arg $namedArgument) use ($methodName): Rules\RuleError {
+                    /** @var Node\Identifier $argumentName */
+                    $argumentName = $namedArgument->name;
+
+                    $message = \sprintf(
+                        'Method %s() is invoked with named argument for parameter $%s.',
+                        $methodName,
+                        $argumentName->toString(),
+                    );
+
+                    return Rules\RuleErrorBuilder::message($message)
+                        ->identifier(ErrorIdentifier::noNamedArgument()->toString())
+                        ->build();
+                }, $namedArguments);
+            }
 
             return \array_map(static function (Node\Arg $namedArgument) use ($className, $methodName): Rules\RuleError {
                 /** @var Node\Identifier $argumentName */

--- a/test/Fixture/CallLikes/NoNamedArgumentRule/script.php
+++ b/test/Fixture/CallLikes/NoNamedArgumentRule/script.php
@@ -114,3 +114,9 @@ $anonymousClass = new class() implements ExampleInterface {
 
 $anonymousClass->bar(1, 2);
 $anonymousClass->bar(baz: 1, 2);
+
+$exampleClass::create(1);
+$exampleClass::create(bar: 1);
+
+$anonymousClass::create(1);
+$anonymousClass::create(bar: 1);

--- a/test/Integration/CallLikes/NoNamedArgumentRuleTest.php
+++ b/test/Integration/CallLikes/NoNamedArgumentRuleTest.php
@@ -180,6 +180,14 @@ final class NoNamedArgumentRuleTest extends Testing\RuleTestCase
                     'Method bar() of anonymous class is invoked with named argument for parameter $baz.',
                     116,
                 ],
+                [
+                    'Method create() is invoked with named argument for parameter $bar.',
+                    119,
+                ],
+                [
+                    'Method create() is invoked with named argument for parameter $bar.',
+                    122,
+                ],
             ],
         );
     }


### PR DESCRIPTION
This pull request

- [x] adjusts the  `CallLikes\NoNamedArgumentRule` to handle `static` calls on variable expressions

