### PR TITLE
Fix: Adjust `CallLikes\NoNamedArgumentRule` to handle calls on invokables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`2.10.3...main`][2.10.3...main].
 ### Fixed
 
 - Adjusted `Methods\NoNamedArgumentRule` to handle static calls on variable expressions ([#947]), by [@localheinz]
+- Adjusted `Methods\NoNamedArgumentRule` to handle calls on invokables ([#948]), by [@localheinz]
 
 ## [`2.10.3`][2.10.3]
 
@@ -689,6 +690,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [#943]: https://github.com/ergebnis/phpstan-rules/pull/943
 [#944]: https://github.com/ergebnis/phpstan-rules/pull/944
 [#947]: https://github.com/ergebnis/phpstan-rules/pull/947
+[#948]: https://github.com/ergebnis/phpstan-rules/pull/948
 
 [@cosmastech]: https://github.com/cosmastech
 [@enumag]: https://github.com/enumag

--- a/src/CallLikes/NoNamedArgumentRule.php
+++ b/src/CallLikes/NoNamedArgumentRule.php
@@ -80,7 +80,7 @@ final class NoNamedArgumentRule implements Rules\Rule
 
             if ($functionName instanceof Node\Expr\Variable) {
                 return \sprintf(
-                    'Anonymous function referenced by $%s',
+                    'Callable referenced by $%s',
                     $functionName->name,
                 );
             }

--- a/test/Fixture/CallLikes/NoNamedArgumentRule/InvokableClass.php
+++ b/test/Fixture/CallLikes/NoNamedArgumentRule/InvokableClass.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\CallLikes\NoNamedArgumentRule;
+
+final class InvokableClass
+{
+    public function __invoke($bar): void
+    {
+    }
+}

--- a/test/Fixture/CallLikes/NoNamedArgumentRule/script.php
+++ b/test/Fixture/CallLikes/NoNamedArgumentRule/script.php
@@ -120,3 +120,8 @@ $exampleClass::create(bar: 1);
 
 $anonymousClass::create(1);
 $anonymousClass::create(bar: 1);
+
+$invokableClass = new InvokableClass();
+
+$invokableClass(1);
+$invokableClass(bar: 1);

--- a/test/Integration/CallLikes/NoNamedArgumentRuleTest.php
+++ b/test/Integration/CallLikes/NoNamedArgumentRuleTest.php
@@ -47,7 +47,7 @@ final class NoNamedArgumentRuleTest extends Testing\RuleTestCase
                     17,
                 ],
                 [
-                    'Anonymous function referenced by $bar is invoked with named argument for parameter $baz.',
+                    'Callable referenced by $bar is invoked with named argument for parameter $baz.',
                     26,
                 ],
                 [
@@ -187,6 +187,10 @@ final class NoNamedArgumentRuleTest extends Testing\RuleTestCase
                 [
                     'Method create() is invoked with named argument for parameter $bar.',
                     122,
+                ],
+                [
+                    'Callable referenced by $invokableClass is invoked with named argument for parameter $bar.',
+                    127,
                 ],
             ],
         );


### PR DESCRIPTION
This pull request

- [x] adds a test case for invoking an invokable with named arguments
- [x] adjusts `CallLikes\NoNamedArgumentRule` to handle calls on invokables

Related to https://github.com/ergebnis/phpstan-rules/issues/946.