### PR TITLE
Fix: Adjust `CallLikes\NoNamedArgumentRule` to handle calls on callables assigned to properties

### DIFF
--- a/.php-cs-fixer.fixture.php
+++ b/.php-cs-fixer.fixture.php
@@ -39,6 +39,7 @@ $config = PhpCsFixer\Config\Factory::fromRuleSet($ruleSet);
 $config->getFinder()
     ->in(__DIR__ . '/test/Fixture/')
     ->notPath([
+        'CallLikes/NoNamedArgumentRule/ClassUsingInvokableClass.php',
         'CallLikes/NoNamedArgumentRule/script.php',
         'Closures/NoNullableReturnTypeDeclarationRule/script.php',
         'Closures/NoParameterWithNullableTypeDeclarationRule/script.php',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`2.10.3...main`][2.10.3...main].
 
 - Adjusted `Methods\NoNamedArgumentRule` to handle static calls on variable expressions ([#947]), by [@localheinz]
 - Adjusted `Methods\NoNamedArgumentRule` to handle calls on invokables ([#948]), by [@localheinz]
+- Adjusted `Methods\NoNamedArgumentRule` to handle calls on callables assigned to properties ([#949]), by [@localheinz]
 
 ## [`2.10.3`][2.10.3]
 
@@ -691,6 +692,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [#944]: https://github.com/ergebnis/phpstan-rules/pull/944
 [#947]: https://github.com/ergebnis/phpstan-rules/pull/947
 [#948]: https://github.com/ergebnis/phpstan-rules/pull/948
+[#949]: https://github.com/ergebnis/phpstan-rules/pull/949
 
 [@cosmastech]: https://github.com/cosmastech
 [@enumag]: https://github.com/enumag

--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -21,6 +21,7 @@
     "PhpParser\\Node\\Expr\\Isset_",
     "PhpParser\\Node\\Expr\\MethodCall",
     "PhpParser\\Node\\Expr\\New_",
+    "PhpParser\\Node\\Expr\\PropertyFetch",
     "PhpParser\\Node\\Expr\\StaticCall",
     "PhpParser\\Node\\Expr\\Variable",
     "PhpParser\\Node\\Identifier",

--- a/src/CallLikes/NoNamedArgumentRule.php
+++ b/src/CallLikes/NoNamedArgumentRule.php
@@ -78,6 +78,13 @@ final class NoNamedArgumentRule implements Rules\Rule
         if ($node instanceof Node\Expr\FuncCall) {
             $functionName = $node->name;
 
+            if ($functionName instanceof Node\Expr\PropertyFetch) {
+                return \sprintf(
+                    'Callable referenced by property $%s',
+                    $functionName->name,
+                );
+            }
+
             if ($functionName instanceof Node\Expr\Variable) {
                 return \sprintf(
                     'Callable referenced by $%s',

--- a/test/Fixture/CallLikes/NoNamedArgumentRule/ClassUsingInvokableClass.php
+++ b/test/Fixture/CallLikes/NoNamedArgumentRule/ClassUsingInvokableClass.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Ergebnis\PHPStan\Rules\Test\Fixture\CallLikes\NoNamedArgumentRule;
+
+final class ClassUsingInvokableClass
+{
+    private InvokableClass $invokableClass;
+
+    public function __construct(InvokableClass $invokableClass)
+    {
+        $this->invokableClass = $invokableClass;
+    }
+
+    public function bar($baz): void
+    {
+        ($this->invokableClass)($baz);
+        ($this->invokableClass)(bar: $baz);
+    }
+}

--- a/test/Integration/CallLikes/NoNamedArgumentRuleTest.php
+++ b/test/Integration/CallLikes/NoNamedArgumentRuleTest.php
@@ -35,6 +35,10 @@ final class NoNamedArgumentRuleTest extends Testing\RuleTestCase
             self::phpFilesIn(__DIR__ . '/../../Fixture/CallLikes/NoNamedArgumentRule'),
             [
                 [
+                    'Callable referenced by property $invokableClass is invoked with named argument for parameter $bar.',
+                    17,
+                ],
+                [
                     'Function json_encode() is invoked with named argument for parameter $value.',
                     8,
                 ],


### PR DESCRIPTION
This pull request

- [x] adds a test case for invoking invokable assigned to instance property with named arguments
- [x] adjusts `CallLikes\NoNamedArgumentRule` to handle calls on callables assigned to properties

Fixes #946.