### PR TITLE
Fix: Adjust `CallLikes\NoNamedArgumentRule` to handle other calls with generic error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a full diff see [`2.10.3...main`][2.10.3...main].
 - Adjusted `Methods\NoNamedArgumentRule` to handle static calls on variable expressions ([#947]), by [@localheinz]
 - Adjusted `Methods\NoNamedArgumentRule` to handle calls on invokables ([#948]), by [@localheinz]
 - Adjusted `Methods\NoNamedArgumentRule` to handle calls on callables assigned to properties ([#949]), by [@localheinz]
+- Adjusted `Methods\NoNamedArgumentRule` to handle all other calls with generic error message ([#951]), by [@localheinz]
 
 ## [`2.10.3`][2.10.3]
 
@@ -693,6 +694,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [#947]: https://github.com/ergebnis/phpstan-rules/pull/947
 [#948]: https://github.com/ergebnis/phpstan-rules/pull/948
 [#949]: https://github.com/ergebnis/phpstan-rules/pull/949
+[#951]: https://github.com/ergebnis/phpstan-rules/pull/951
 
 [@cosmastech]: https://github.com/cosmastech
 [@enumag]: https://github.com/enumag

--- a/src/CallLikes/NoNamedArgumentRule.php
+++ b/src/CallLikes/NoNamedArgumentRule.php
@@ -92,10 +92,12 @@ final class NoNamedArgumentRule implements Rules\Rule
                 );
             }
 
-            return \sprintf(
-                'Function %s()',
-                $functionName,
-            );
+            if ($functionName instanceof Node\Name) {
+                return \sprintf(
+                    'Function %s()',
+                    $functionName,
+                );
+            }
         }
 
         if ($node instanceof Node\Expr\MethodCall) {
@@ -159,6 +161,6 @@ final class NoNamedArgumentRule implements Rules\Rule
             );
         }
 
-        throw new ShouldNotHappenException();
+        return 'Callable';
     }
 }

--- a/test/Fixture/CallLikes/NoNamedArgumentRule/ClassUsingInvokableClass.php
+++ b/test/Fixture/CallLikes/NoNamedArgumentRule/ClassUsingInvokableClass.php
@@ -16,4 +16,9 @@ final class ClassUsingInvokableClass
         ($this->invokableClass)($baz);
         ($this->invokableClass)(bar: $baz);
     }
+
+    public function baz(): InvokableClass
+    {
+        return $this->invokableClass;
+    }
 }

--- a/test/Fixture/CallLikes/NoNamedArgumentRule/script.php
+++ b/test/Fixture/CallLikes/NoNamedArgumentRule/script.php
@@ -146,3 +146,8 @@ $firstClassCallable = $exampleClass->bar(...);
 
 $firstClassCallable(1);
 $firstClassCallable(bar: 1);
+
+$classUsingInvokableClass = new ClassUsingInvokableClass(new InvokableClass());
+
+($classUsingInvokableClass->baz())(1);
+($classUsingInvokableClass->baz())(bar: 1);

--- a/test/Integration/CallLikes/NoNamedArgumentRuleTest.php
+++ b/test/Integration/CallLikes/NoNamedArgumentRuleTest.php
@@ -208,6 +208,10 @@ final class NoNamedArgumentRuleTest extends Testing\RuleTestCase
                     'Callable referenced by $firstClassCallable is invoked with named argument for parameter $bar.',
                     148,
                 ],
+                [
+                    'Callable is invoked with named argument for parameter $bar.',
+                    153,
+                ],
             ],
         );
     }


### PR DESCRIPTION
This pull request

- [x] adds a test case for invoking an invokable returned by a method call with named arguments
- [x] adjust `CallLikes\NoNamedArgumentRule` to handle other calls with generic error message