### PR TITLE
Fix: Adjust `CallLikes\NoNamedArgumentRule` to handle calls to constructors of variable class names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.10.4...main`][2.10.4...main].
 
+### Fixed
+
+- Adjusted `Methods\NoNamedArgumentRule` to handle calls to constructors of variable class names ([#957]), by [@localheinz]
+
 ## [`2.10.4`][2.10.4]
 
 For a full diff see [`2.10.3...2.10.4`][2.10.3...2.10.4].

--- a/src/CallLikes/NoNamedArgumentRule.php
+++ b/src/CallLikes/NoNamedArgumentRule.php
@@ -152,13 +152,16 @@ final class NoNamedArgumentRule implements Rules\Rule
         }
 
         if ($node instanceof Node\Expr\New_) {
-            /** @var Node\Name\FullyQualified $className */
             $className = $node->class;
 
-            return \sprintf(
-                'Constructor of %s',
-                $className->toString(),
-            );
+            if ($className instanceof Node\Name) {
+                return \sprintf(
+                    'Constructor of %s',
+                    $className->toString(),
+                );
+            }
+
+            return 'Constructor';
         }
 
         return 'Callable';

--- a/test/Fixture/CallLikes/NoNamedArgumentRule/script.php
+++ b/test/Fixture/CallLikes/NoNamedArgumentRule/script.php
@@ -151,3 +151,9 @@ $classUsingInvokableClass = new ClassUsingInvokableClass(new InvokableClass());
 
 ($classUsingInvokableClass->baz())(1);
 ($classUsingInvokableClass->baz())(bar: 1);
+
+$className = ExampleClass::class;
+
+new $className();
+new $className(1);
+new $className(bar: 1);

--- a/test/Integration/CallLikes/NoNamedArgumentRuleTest.php
+++ b/test/Integration/CallLikes/NoNamedArgumentRuleTest.php
@@ -212,6 +212,10 @@ final class NoNamedArgumentRuleTest extends Testing\RuleTestCase
                     'Callable is invoked with named argument for parameter $bar.',
                     153,
                 ],
+                [
+                    'Constructor is invoked with named argument for parameter $bar.',
+                    159,
+                ],
             ],
         );
     }


### PR DESCRIPTION
This pull request

- [x] add test cases using variable class names
- [ ] adjusts `CallLikes\NoNamedArgumentRule` to handle calls to constructors of variable class names

Fixes #952.