### PR TITLE
Fix: Adjust `CallLikes\NoNamedArgumentRule` to describe known calls only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`2.10.4...main`][2.10.4...main].
 ### Fixed
 
 - Adjusted `Methods\NoNamedArgumentRule` to handle calls to constructors of variable class names ([#957]), by [@localheinz]
+- Adjusted `Methods\NoNamedArgumentRule` to describe known calls only ([#958]), by [@localheinz]
 
 ## [`2.10.4`][2.10.4]
 
@@ -706,6 +707,7 @@ For a full diff see [`362c7ea...0.1.0`][362c7ea...0.1.0].
 [#949]: https://github.com/ergebnis/phpstan-rules/pull/949
 [#951]: https://github.com/ergebnis/phpstan-rules/pull/951
 [#957]: https://github.com/ergebnis/phpstan-rules/pull/957
+[#958]: https://github.com/ergebnis/phpstan-rules/pull/958
 
 [@cosmastech]: https://github.com/cosmastech
 [@enumag]: https://github.com/enumag

--- a/src/CallLikes/NoNamedArgumentRule.php
+++ b/src/CallLikes/NoNamedArgumentRule.php
@@ -101,54 +101,60 @@ final class NoNamedArgumentRule implements Rules\Rule
         }
 
         if ($node instanceof Node\Expr\MethodCall) {
-            /** @var Node\Identifier $methodName */
             $methodName = $node->name;
 
-            $objectType = $scope->getType($node->var);
+            if ($methodName instanceof Node\Identifier) {
+                $objectType = $scope->getType($node->var);
 
-            $methodReflection = $scope->getMethodReflection(
-                $objectType,
-                $methodName->name,
-            );
+                $methodReflection = $scope->getMethodReflection(
+                    $objectType,
+                    $methodName->name,
+                );
 
-            if (null === $methodReflection) {
-                throw new ShouldNotHappenException();
-            }
+                if (null === $methodReflection) {
+                    throw new ShouldNotHappenException();
+                }
 
-            $declaringClass = $methodReflection->getDeclaringClass();
+                $declaringClass = $methodReflection->getDeclaringClass();
 
-            if ($declaringClass->isAnonymous()) {
+                if ($declaringClass->isAnonymous()) {
+                    return \sprintf(
+                        'Method %s() of anonymous class',
+                        $methodName->toString(),
+                    );
+                }
+
                 return \sprintf(
-                    'Method %s() of anonymous class',
-                    $methodName,
+                    'Method %s::%s()',
+                    $declaringClass->getName(),
+                    $methodName->toString(),
                 );
             }
 
-            return \sprintf(
-                'Method %s::%s()',
-                $declaringClass->getName(),
-                $methodName,
-            );
+            return 'Method';
         }
 
         if ($node instanceof Node\Expr\StaticCall) {
-            $className = $node->class;
-
-            /** @var Node\Identifier $methodName */
             $methodName = $node->name;
 
-            if ($className instanceof Node\Expr\Variable) {
+            if ($methodName instanceof Node\Identifier) {
+                $className = $node->class;
+
+                if ($className instanceof Node\Name) {
+                    return \sprintf(
+                        'Method %s::%s()',
+                        $className->toString(),
+                        $methodName->toString(),
+                    );
+                }
+
                 return \sprintf(
                     'Method %s()',
-                    $methodName,
+                    $methodName->toString(),
                 );
             }
 
-            return \sprintf(
-                'Method %s::%s()',
-                $className,
-                $methodName,
-            );
+            return 'Method';
         }
 
         if ($node instanceof Node\Expr\New_) {


### PR DESCRIPTION
This pull request

- [x] adjusts `CallLikes\NoNamedArgumentRule` to describe known calls only
