### PR TITLE
Fix: Update error identifier in NoParameterPassedByReferenceRule

### DIFF
--- a/src/Functions/NoParameterPassedByReferenceRule.php
+++ b/src/Functions/NoParameterPassedByReferenceRule.php
@@ -60,7 +60,7 @@ final class NoParameterPassedByReferenceRule implements Rules\Rule
             );
 
             return Rules\RuleErrorBuilder::message($message)
-                ->identifier(ErrorIdentifier::noParameterWithNullDefaultValue()->toString())
+                ->identifier(ErrorIdentifier::noParameterPassedByReference()->toString())
                 ->build();
         }, $parametersPassedByReference);
     }


### PR DESCRIPTION
This pull request

- [x] fixes `Functions\NoParameterPassedByReferenceRule` to use the correct error identifier